### PR TITLE
feat(web): add optimism client and unify viem clients

### DIFF
--- a/web/app/crons/balance-flow-rates/route.ts
+++ b/web/app/crons/balance-flow-rates/route.ts
@@ -5,7 +5,7 @@ import { base } from "viem/chains"
 import { waitForTransactionReceipt } from "viem/actions"
 import { nounsFlowImplAbi } from "@/lib/abis"
 import { getContract } from "viem"
-import { l2Client } from "@/lib/viem/client"
+import { getClient } from "@/lib/viem/client"
 
 export const dynamic = "force-dynamic"
 export const revalidate = 0
@@ -20,7 +20,7 @@ export async function GET() {
     const contract = getContract({
       address: NOUNS_FLOW,
       abi: nounsFlowImplAbi,
-      client: l2Client,
+      client: getClient(base.id),
     })
 
     // Read the number of child flows that are out of sync

--- a/web/app/crons/reveal-votes/route.ts
+++ b/web/app/crons/reveal-votes/route.ts
@@ -5,7 +5,7 @@ import { generateKVKey, SavedVote } from "@/lib/kv/disputeVote"
 import { getRevealVotesWalletClient } from "@/lib/viem/walletClient"
 import { base } from "viem/chains"
 import { erc20VotesArbitratorImplAbi } from "@/lib/abis"
-import { l2Client } from "@/lib/viem/client"
+import { getClient } from "@/lib/viem/client"
 import { waitForTransactionReceipt } from "viem/actions"
 
 export const dynamic = "force-dynamic"
@@ -45,7 +45,7 @@ export async function GET() {
         }
 
         // Check if vote is already revealed
-        const receipt = await l2Client.readContract({
+        const receipt = await getClient(base.id).readContract({
           address: arbitrator as `0x${string}`,
           abi: erc20VotesArbitratorImplAbi,
           functionName: "getReceipt",
@@ -58,7 +58,7 @@ export async function GET() {
         }
 
         // Get the latest nonce for the account
-        const nonce = await l2Client.getTransactionCount({
+        const nonce = await getClient(base.id).getTransactionCount({
           address: client.account.address,
         })
 

--- a/web/app/flow/[flowId]/components/flow-submenu.tsx
+++ b/web/app/flow/[flowId]/components/flow-submenu.tsx
@@ -67,12 +67,13 @@ export const FlowSubmenu = async (props: Props) => {
   }
 
   if (showDrafts) {
-  links.push({
-    label: "Drafts",
-    href: `/flow/${flowId}/drafts`,
-    isActive: isDrafts,
-    badge: draftsCount,
-  })
+    links.push({
+      label: "Drafts",
+      href: `/flow/${flowId}/drafts`,
+      isActive: isDrafts,
+      badge: draftsCount,
+    })
+  }
 
   return (
     <div className="mb-4 mt-14 flex items-center justify-between md:mb-8">

--- a/web/app/flow/[flowId]/hooks/get-owner.ts
+++ b/web/app/flow/[flowId]/hooks/get-owner.ts
@@ -1,9 +1,14 @@
 import { nounsFlowImplAbi } from "@/lib/abis"
-import { l2Client } from "@/lib/viem/client"
+import { getClient } from "@/lib/viem/client"
 import { getContract } from "viem"
+import { base } from "viem/chains"
 
 export async function getOwner(address: `0x${string}`) {
-  const contract = getContract({ address, abi: nounsFlowImplAbi, client: l2Client })
+  const contract = getContract({
+    address,
+    abi: nounsFlowImplAbi,
+    client: getClient(base.id),
+  })
 
   const owner = await contract.read.owner()
   return owner as `0x${string}`

--- a/web/app/token/hooks/buy-token-quotes.ts
+++ b/web/app/token/hooks/buy-token-quotes.ts
@@ -1,13 +1,13 @@
 "use server"
 
 import { tokenEmitterImplAbi } from "@/lib/abis"
-import { l2Client } from "@/lib/viem/client"
+import { getClient } from "@/lib/viem/client"
 import type { Address } from "viem"
 import { base } from "viem/chains"
 
 export async function getTokenQuote(contract: Address, amount: bigint, chainId = base.id) {
   try {
-    const data = await l2Client.readContract({
+    const data = await getClient(chainId).readContract({
       abi: tokenEmitterImplAbi,
       address: contract,
       functionName: "buyTokenQuote",
@@ -35,7 +35,7 @@ export async function getTokenQuoteWithRewards(
   chainId = base.id,
 ) {
   try {
-    const data = await l2Client.readContract({
+    const data = await getClient(chainId).readContract({
       abi: tokenEmitterImplAbi,
       address: contract,
       functionName: "buyTokenQuoteWithRewards",

--- a/web/app/token/hooks/sell-token-quotes.ts
+++ b/web/app/token/hooks/sell-token-quotes.ts
@@ -1,13 +1,13 @@
 "use server"
 
 import { tokenEmitterImplAbi } from "@/lib/abis"
-import { l2Client } from "@/lib/viem/client"
+import { getClient } from "@/lib/viem/client"
 import type { Address } from "viem"
 import { base } from "viem/chains"
 
 export async function getSellTokenQuote(contract: Address, amount: number, chainId = base.id) {
   try {
-    const data = await l2Client.readContract({
+    const data = await getClient(chainId).readContract({
       abi: tokenEmitterImplAbi,
       address: contract,
       functionName: "sellTokenQuote",

--- a/web/app/token/hooks/use-buy-token-relay.ts
+++ b/web/app/token/hooks/use-buy-token-relay.ts
@@ -5,7 +5,7 @@ import { base, mainnet } from "viem/chains"
 import { useAccount } from "wagmi"
 import { tokenEmitterImplAbi } from "@/lib/abis"
 import { createRelayClient } from "@/lib/relay/client"
-import { getChain, l1Client, l2Client } from "@/lib/viem/client"
+import { getChain, getClient } from "@/lib/viem/client"
 
 const toChainId = base.id
 
@@ -33,7 +33,7 @@ export const useBuyTokenRelay = () => {
     onSuccess: (hash: string) => void
     successMessage: string
   }) => {
-    const publicClient = chainId === mainnet.id ? l1Client : l2Client
+    const publicClient = getClient(chainId)
 
     const { request } = await publicClient.simulateContract({
       address: tokenEmitter,

--- a/web/components/global/curator-popover/hooks/get-user-total-rewards-balance.ts
+++ b/web/components/global/curator-popover/hooks/get-user-total-rewards-balance.ts
@@ -2,7 +2,8 @@
 
 import { Address } from "viem"
 import { rewardPoolImplAbi } from "@/lib/abis"
-import { l2Client } from "@/lib/viem/client"
+import { getClient } from "@/lib/viem/client"
+import { base } from "viem/chains"
 import { unstable_cache } from "next/cache"
 import { getEthAddress } from "@/lib/utils"
 
@@ -11,7 +12,7 @@ export const getUserTotalRewardsBalance = unstable_cache(
     try {
       const claimableBalances = await Promise.all(
         pools.map((pool) =>
-          l2Client.readContract({
+          getClient(base.id).readContract({
             address: getEthAddress(pool) as Address,
             abi: rewardPoolImplAbi,
             functionName: "getClaimableBalanceNow",
@@ -22,7 +23,7 @@ export const getUserTotalRewardsBalance = unstable_cache(
 
       const memberFlowRates = await Promise.all(
         pools.map((pool) =>
-          l2Client.readContract({
+          getClient(base.id).readContract({
             address: getEthAddress(pool) as Address,
             abi: rewardPoolImplAbi,
             functionName: "getMemberFlowRate",

--- a/web/components/global/curator-popover/hooks/get-voter-rewards-balance.ts
+++ b/web/components/global/curator-popover/hooks/get-voter-rewards-balance.ts
@@ -1,6 +1,7 @@
 import { erc20VotesArbitratorImplAbi } from "@/lib/abis"
 import { getEthAddress } from "@/lib/utils"
-import { l2Client } from "@/lib/viem/client"
+import { getClient } from "@/lib/viem/client"
+import { base } from "viem/chains"
 import type { Address } from "viem"
 
 export async function getVoterRewardsBalance(
@@ -9,7 +10,7 @@ export async function getVoterRewardsBalance(
   round: bigint,
   userAddress: Address,
 ): Promise<bigint> {
-  const balance = await l2Client.readContract({
+  const balance = await getClient(base.id).readContract({
     address: getEthAddress(arbitratorAddress),
     abi: erc20VotesArbitratorImplAbi,
     functionName: "getRewardsForRound",

--- a/web/components/global/hooks/get-claimable-balance.ts
+++ b/web/components/global/hooks/get-claimable-balance.ts
@@ -1,11 +1,12 @@
 import { nounsFlowImplAbi } from "@/lib/abis"
-import { l2Client } from "@/lib/viem/client"
+import { getClient } from "@/lib/viem/client"
+import { base } from "viem/chains"
 
 export async function getClaimableBalance(contract: `0x${string}`, address?: `0x${string}`) {
   if (!address) return BigInt(0)
 
   try {
-    const balance = await l2Client.readContract({
+    const balance = await getClient(base.id).readContract({
       address: contract,
       abi: nounsFlowImplAbi,
       functionName: "getClaimableBalance",

--- a/web/components/global/hooks/get-claimable-pool-balance.ts
+++ b/web/components/global/hooks/get-claimable-pool-balance.ts
@@ -1,7 +1,8 @@
 "use server"
 
 import { superfluidPoolAbi } from "@/lib/abis"
-import { l2Client } from "@/lib/viem/client"
+import { getClient } from "@/lib/viem/client"
+import { base } from "viem/chains"
 import type { Address } from "viem"
 
 export async function getClaimablePoolBalance(
@@ -13,7 +14,7 @@ export async function getClaimablePoolBalance(
   }
 
   try {
-    const balance = await l2Client.readContract({
+    const balance = await getClient(base.id).readContract({
       address: pool,
       abi: superfluidPoolAbi,
       functionName: "getClaimableNow",

--- a/web/components/global/recipient-popover/get-grants-claimable-balance.ts
+++ b/web/components/global/recipient-popover/get-grants-claimable-balance.ts
@@ -2,7 +2,8 @@
 
 import { Address } from "viem"
 import { nounsFlowImplAbi } from "@/lib/abis"
-import { l2Client } from "@/lib/viem/client"
+import { getClient } from "@/lib/viem/client"
+import { base } from "viem/chains"
 import { unstable_cache } from "next/cache"
 
 export const getGrantsClaimableBalance = unstable_cache(
@@ -10,7 +11,7 @@ export const getGrantsClaimableBalance = unstable_cache(
     try {
       const balances = await Promise.all(
         contracts.map((contract) =>
-          l2Client.readContract({
+          getClient(base.id).readContract({
             address: contract as Address,
             abi: nounsFlowImplAbi,
             functionName: "getClaimableBalance",

--- a/web/lib/allocation/owner-proofs/proofs.ts
+++ b/web/lib/allocation/owner-proofs/proofs.ts
@@ -1,5 +1,6 @@
 import { NOUNS_TOKEN } from "@/lib/config"
-import { l1Client, l2Client } from "@/lib/viem/client"
+import { getClient } from "@/lib/viem/client"
+import { base, mainnet } from "viem/chains"
 import { encodeAbiParameters, keccak256, PublicClient, toHex, type Address } from "viem"
 import { getBeaconBlock } from "./get-beacon-block"
 import { getBeaconRootAndL2Timestamp } from "./get-beacon-root-and-l2-timestamp"
@@ -19,7 +20,9 @@ export async function generateOwnerProofs(tokens: { id: bigint; owner: Address }
 
     // Step 1: Get the latest beacon root and L2 timestamp
     // This function retrieves the parentBeaconBlockRoot and timestamp from the latest L2 block
-    const beaconInfo = await getBeaconRootAndL2Timestamp(l2Client as PublicClient)
+    const beaconInfo = await getBeaconRootAndL2Timestamp(
+      getClient(base.id) as PublicClient,
+    )
 
     // Step 2: Fetch the beacon block using the beacon root
     // This function makes an API call to retrieve the beacon block data
@@ -43,7 +46,7 @@ export async function generateOwnerProofs(tokens: { id: bigint; owner: Address }
             )
 
             // Step 4: Get the storage proof from the L1 client
-            const proof = await l1Client.getProof({
+            const proof = await getClient(mainnet.id).getProof({
               address: NOUNS_TOKEN,
               storageKeys: [slot],
               blockNumber: BigInt(block.body.executionPayload.blockNumber),
@@ -66,7 +69,7 @@ export async function generateOwnerProofs(tokens: { id: bigint; owner: Address }
         )
 
         // Get the storage proof from the L1 client
-        const proof = await l1Client.getProof({
+        const proof = await getClient(mainnet.id).getProof({
           address: NOUNS_TOKEN,
           storageKeys: [slot],
           blockNumber: BigInt(block.body.executionPayload.blockNumber),

--- a/web/lib/auth/ens.ts
+++ b/web/lib/auth/ens.ts
@@ -1,6 +1,5 @@
 "use server"
 
-import { l1Client } from "@/lib/viem/client"
 import { unstable_cache } from "next/cache"
 import { getEnsName, normalize } from "viem/ens"
 import { getClient } from "@/lib/viem/client"
@@ -9,7 +8,7 @@ import { mainnet } from "viem/chains"
 export const getEnsNameFromAddress = unstable_cache(
   async (address: `0x${string}`): Promise<string | null> => {
     try {
-      return await getEnsName(l1Client, { address })
+      return await getEnsName(getClient(mainnet.id), { address })
     } catch (error) {
       console.error("Error fetching ENS name:", error)
       return null
@@ -22,7 +21,7 @@ export const getEnsNameFromAddress = unstable_cache(
 export const getEnsAvatar = unstable_cache(
   async (ensNameOrAddress: string): Promise<string | null> => {
     try {
-      return await l1Client.getEnsAvatar({ name: ensNameOrAddress })
+      return await getClient(mainnet.id).getEnsAvatar({ name: ensNameOrAddress })
     } catch (error) {
       console.error("Error fetching ENS avatar:", error)
       return null

--- a/web/lib/tcr/get-arbitrator-voting-power.ts
+++ b/web/lib/tcr/get-arbitrator-voting-power.ts
@@ -1,7 +1,8 @@
 "use server"
 
 import type { Address } from "viem"
-import { l2Client } from "@/lib/viem/client"
+import { getClient } from "@/lib/viem/client"
+import { base } from "viem/chains"
 import { erc20VotesArbitratorImplAbi } from "../abis"
 
 export async function getVotingPower(contract: Address, disputeId: string, address?: Address) {
@@ -13,7 +14,7 @@ export async function getVotingPower(contract: Address, disputeId: string, addre
   }
 
   try {
-    const votingPower = await l2Client.readContract({
+    const votingPower = await getClient(base.id).readContract({
       abi: erc20VotesArbitratorImplAbi,
       address: contract,
       functionName: "votingPowerInCurrentRound",

--- a/web/lib/tcr/get-erc20-supply.ts
+++ b/web/lib/tcr/get-erc20-supply.ts
@@ -1,7 +1,8 @@
 "use server"
 
 import { type Address, erc20Abi } from "viem"
-import { l2Client } from "@/lib/viem/client"
+import { getClient } from "@/lib/viem/client"
+import { base } from "viem/chains"
 
 export async function getERC20Supply(contract: Address | undefined) {
   if (!contract) {
@@ -9,7 +10,7 @@ export async function getERC20Supply(contract: Address | undefined) {
   }
 
   try {
-    const totalSupply = await l2Client.readContract({
+    const totalSupply = await getClient(base.id).readContract({
       abi: erc20Abi,
       address: contract,
       functionName: "totalSupply",

--- a/web/lib/tcr/get-tcr-costs.ts
+++ b/web/lib/tcr/get-tcr-costs.ts
@@ -3,7 +3,8 @@ import "server-only"
 import { unstable_cache } from "next/cache"
 import { erc20Abi, getContract } from "viem"
 import { flowTcrImplAbi } from "../abis"
-import { l2Client } from "../viem/client"
+import { getClient } from "../viem/client"
+import { base } from "viem/chains"
 import { getEthAddress } from "../utils"
 
 export async function getTcrCosts(tcrAddress: string | null, erc20Address: string | null) {
@@ -17,7 +18,11 @@ export async function getTcrCosts(tcrAddress: string | null, erc20Address: strin
 }
 
 async function readTcrCosts(tcrAddress: `0x${string}`, erc20Address: `0x${string}`) {
-  const tcr = getContract({ address: tcrAddress, abi: flowTcrImplAbi, client: l2Client })
+  const tcr = getContract({
+    address: tcrAddress,
+    abi: flowTcrImplAbi,
+    client: getClient(base.id),
+  })
 
   const [
     addItemCost,
@@ -27,7 +32,11 @@ async function readTcrCosts(tcrAddress: `0x${string}`, erc20Address: `0x${string
     arbitrationCost,
   ] = await tcr.read.getTotalCosts()
 
-  const erc20 = getContract({ address: erc20Address, abi: erc20Abi, client: l2Client })
+  const erc20 = getContract({
+    address: erc20Address,
+    abi: erc20Abi,
+    client: getClient(base.id),
+  })
 
   const symbol = await erc20.read.symbol()
 

--- a/web/lib/tcr/get-token-data.ts
+++ b/web/lib/tcr/get-token-data.ts
@@ -1,7 +1,8 @@
 "use server"
 
 import { Address, erc20Abi } from "viem"
-import { l2Client } from "@/lib/viem/client"
+import { getClient } from "@/lib/viem/client"
+import { base } from "viem/chains"
 import { getContract } from "viem"
 
 export async function getTokenData(
@@ -12,7 +13,7 @@ export async function getTokenData(
   const erc20Contract = getContract({
     address: contract,
     abi: erc20Abi,
-    client: l2Client,
+    client: getClient(base.id),
   })
 
   const [allowance, symbol, name, balance] = await Promise.all([

--- a/web/lib/viem/client.ts
+++ b/web/lib/viem/client.ts
@@ -1,24 +1,38 @@
 import { createPublicClient, http } from "viem"
-import { base, mainnet } from "viem/chains"
+import { base, mainnet, optimism } from "viem/chains"
 
-export const l1Client = createPublicClient({
+const mainnetClient = createPublicClient({
   chain: mainnet,
-  transport: http(`https://eth-mainnet.g.alchemy.com/v2/${process.env.NEXT_PUBLIC_ALCHEMY_ID}`),
+  transport: http(
+    `https://eth-mainnet.g.alchemy.com/v2/${process.env.NEXT_PUBLIC_ALCHEMY_ID}`,
+  ),
   batch: { multicall: true },
 })
 
-export const l2Client = createPublicClient({
+const baseClient = createPublicClient({
   chain: base,
-  transport: http(`https://base-mainnet.g.alchemy.com/v2/${process.env.NEXT_PUBLIC_ALCHEMY_ID}`),
+  transport: http(
+    `https://base-mainnet.g.alchemy.com/v2/${process.env.NEXT_PUBLIC_ALCHEMY_ID}`,
+  ),
+  batch: { multicall: true },
+})
+
+const optimismClient = createPublicClient({
+  chain: optimism,
+  transport: http(
+    `https://opt-mainnet.g.alchemy.com/v2/${process.env.NEXT_PUBLIC_ALCHEMY_ID}`,
+  ),
   batch: { multicall: true },
 })
 
 export const getClient = (chainId: number) => {
   switch (chainId) {
     case base.id:
-      return l2Client
+      return baseClient
     case mainnet.id:
-      return l1Client
+      return mainnetClient
+    case optimism.id:
+      return optimismClient
     default:
       throw new Error(`Unsupported chainId: ${chainId}`)
   }
@@ -30,6 +44,8 @@ export function getChain(chainId: number) {
       return base
     case mainnet.id:
       return mainnet
+    case optimism.id:
+      return optimism
     default:
       throw new Error(`Unsupported chainId: ${chainId}`)
   }

--- a/web/lib/wagmi/use-wait-for-transactions.ts
+++ b/web/lib/wagmi/use-wait-for-transactions.ts
@@ -2,10 +2,9 @@
 
 import { useState, useEffect, useMemo } from "react"
 import { toast } from "sonner"
-import { getChain, l1Client, l2Client } from "../viem/client"
+import { getChain, getClient } from "../viem/client"
 import { explorerUrl } from "../utils"
 import { waitForTransactionReceipt } from "viem/actions"
-import { base } from "viem/chains"
 
 export const useWaitForTransactions = (
   txHashes: { txHash: string; chainId: number; confirmed: boolean }[],
@@ -32,15 +31,9 @@ export const useWaitForTransactions = (
           onClick: () => window.open(explorerUrl(tx.txHash, tx.chainId)),
         },
       })
-      if (chainId === base.id) {
-        await waitForTransactionReceipt(l2Client, {
-          hash: tx.txHash as `0x${string}`,
-        })
-      } else {
-        await waitForTransactionReceipt(l1Client, {
-          hash: tx.txHash as `0x${string}`,
-        })
-      }
+      await waitForTransactionReceipt(getClient(chainId), {
+        hash: tx.txHash as `0x${string}`,
+      })
 
       setConfirmedTxs((prev) => [...prev, tx.txHash])
       toast.success(`${chainName} transaction confirmed`, { duration: 3000, id: toastId })


### PR DESCRIPTION
## Summary
- support Optimism chain in the viem client
- drop exported l1Client/l2Client and select via getClient
- use getClient across web services
- fix missing brace in FlowSubmenu

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: Binding element implicitly has an 'any' type, etc.)*
- `pnpm build` *(fails: Failed to fetch sha256 checksum from binaries.prisma.sh)*

------
https://chatgpt.com/codex/tasks/task_e_6859ea2f4f9c8327b6593babb59d218d