### PR TITLE
refactor: remove base chain defaults

### DIFF
--- a/web/app/chat/components/tools/challenge-grant-application.tsx
+++ b/web/app/chat/components/tools/challenge-grant-application.tsx
@@ -15,7 +15,6 @@ import type { PropsWithChildren } from "react"
 import { useState } from "react"
 import { toast } from "sonner"
 import { formatEther } from "viem"
-import { base } from "viem/chains"
 import { useAccount } from "wagmi"
 import { useAgentChat } from "../agent-chat"
 import { Textarea } from "@/components/ui/textarea"
@@ -26,7 +25,6 @@ interface Props {
   comment: string | null
 }
 
-const chainId = base.id
 
 export function ChallengeGrantApplication(props: Props) {
   const { grantId, reason: initialReason, comment } = props
@@ -41,8 +39,17 @@ export function ChallengeGrantApplication(props: Props) {
   const { address } = useAccount()
   const { user, append } = useAgentChat()
 
-  const { challengeSubmissionCost, addItemCost, arbitrationCost } = useTcrData(tcrAddress)
-  const token = useTcrToken(erc20Address as `0x${string}`, tcrAddress as `0x${string}`, chainId)
+  const chainId = grant?.flow.chainId ?? grant?.chainId ?? 0
+
+  const { challengeSubmissionCost, addItemCost, arbitrationCost } = useTcrData(
+    tcrAddress,
+    chainId,
+  )
+  const token = useTcrToken(
+    erc20Address as `0x${string}`,
+    tcrAddress as `0x${string}`,
+    chainId,
+  )
 
   const hasEnoughBalance = token.balance >= challengeSubmissionCost
   const hasEnoughAllowance = token.allowance >= challengeSubmissionCost

--- a/web/app/chat/components/tools/request-grant-removal.tsx
+++ b/web/app/chat/components/tools/request-grant-removal.tsx
@@ -14,7 +14,6 @@ import { useContractTransaction } from "@/lib/wagmi/use-contract-transaction"
 import type { PropsWithChildren } from "react"
 import { toast } from "sonner"
 import { formatEther } from "viem"
-import { base } from "viem/chains"
 import { useAccount } from "wagmi"
 import { useAgentChat } from "../agent-chat"
 
@@ -24,7 +23,6 @@ interface Props {
   comment: string | null
 }
 
-const chainId = base.id
 
 export function RequestGrantRemoval(props: Props) {
   const { grantId, reason, comment } = props
@@ -34,7 +32,12 @@ export function RequestGrantRemoval(props: Props) {
   const { address } = useAccount()
   const { user, append } = useAgentChat()
 
-  const { removeItemCost, challengePeriodFormatted } = useTcrData(grant?.flow.tcr as `0x${string}`)
+  const chainId = grant?.flow.chainId ?? grant?.chainId ?? 0
+
+  const { removeItemCost, challengePeriodFormatted } = useTcrData(
+    grant?.flow.tcr as `0x${string}`,
+    chainId,
+  )
   const token = useTcrToken(
     grant?.flow.erc20 as `0x${string}`,
     grant?.flow.tcr as `0x${string}`,

--- a/web/app/dashboard/[id]/components/view-applications.tsx
+++ b/web/app/dashboard/[id]/components/view-applications.tsx
@@ -112,6 +112,7 @@ export function ViewApplications(props: Props) {
                           <AddRecipientToFlowButton
                             draft={application}
                             contract={flowContract}
+                            chainId={startup.chainId}
                             size="sm"
                           />
                         )}

--- a/web/app/draft/[draftId]/page.tsx
+++ b/web/app/draft/[draftId]/page.tsx
@@ -103,6 +103,7 @@ export default async function DraftPage(props: Props) {
                     grantsCount={existingGrants}
                     draft={draft}
                     flow={flow}
+                    chainId={flow.chainId}
                     user={user}
                     tcrAddress={getEthAddress(flow.tcr as `0x${string}`)}
                     erc20Address={getEthAddress(flow.erc20 as `0x${string}`)}

--- a/web/app/draft/[draftId]/self-managed-draft-publish-button.tsx
+++ b/web/app/draft/[draftId]/self-managed-draft-publish-button.tsx
@@ -82,6 +82,7 @@ export function ManagedFlowDraftPublishButton(props: Props) {
           <AddRecipientToFlowButton
             draft={draft}
             contract={flow.recipient as `0x${string}`}
+            chainId={flow.chainId}
             onSuccess={() => {
               ref.current?.click() // close dialog
             }}

--- a/web/app/draft/[draftId]/tcr-draft-publish-button.tsx
+++ b/web/app/draft/[draftId]/tcr-draft-publish-button.tsx
@@ -31,7 +31,6 @@ import { useRouter } from "next/navigation"
 import { useEffect, useRef, useState } from "react"
 import { toast } from "sonner"
 import { encodeAbiParameters, zeroAddress } from "viem"
-import { base } from "viem/chains"
 import { useAccount } from "wagmi"
 import { BuyApplicationFee } from "./buy-application-fee"
 import { publishDraft } from "./publish-draft"
@@ -47,10 +46,9 @@ interface Props {
   tcrAddress: `0x${string}`
   erc20Address: `0x${string}`
   tokenEmitterAddress: `0x${string}`
+  chainId: number
   user?: User
 }
-
-const chainId = base.id
 
 export function TCRDraftPublishButton(props: Props) {
   const {
@@ -67,8 +65,8 @@ export function TCRDraftPublishButton(props: Props) {
   const router = useRouter()
   const ref = useRef<HTMLButtonElement>(null)
 
-  const { addItemCost, challengePeriodFormatted } = useTcrData(tcrAddress)
-  const token = useTcrToken(erc20Address, tcrAddress)
+  const { addItemCost, challengePeriodFormatted } = useTcrData(tcrAddress, chainId)
+  const token = useTcrToken(erc20Address, tcrAddress, chainId)
 
   const { prepareWallet, writeContract, toastId, isLoading } = useContractTransaction({
     chainId,

--- a/web/app/flow/[flowId]/drafts/page.tsx
+++ b/web/app/flow/[flowId]/drafts/page.tsx
@@ -106,6 +106,7 @@ export default async function FlowDraftsPage(props: Props) {
                       tcrAddress={getEthAddress(flow.tcr)}
                       erc20Address={getEthAddress(flow.erc20)}
                       tokenEmitterAddress={getEthAddress(flow.tokenEmitter)}
+                      chainId={flow.chainId}
                       user={user}
                     />
                   </div>

--- a/web/app/token/buy-token-box.tsx
+++ b/web/app/token/buy-token-box.tsx
@@ -6,7 +6,6 @@ import { getEthAddress } from "@/lib/utils"
 import type { RelayChain } from "@reservoir0x/relay-sdk"
 import { useMemo, useState } from "react"
 import type { Address } from "viem"
-import { base } from "viem/chains"
 import { useAccount, useBalance } from "wagmi"
 import { BuyTokenButton } from "./buy-token-button"
 import { ConversionBox } from "./conversion-box"
@@ -25,12 +24,12 @@ interface Props {
   token: Address
   tokenEmitter: Address
   parentFlowContract: Address
+  chainId: number
   onSuccess: (hash: string) => void
   switchSwapBox: () => void
   setTokenAndEmitter: (token: Address, tokenEmitter: Address) => void
 }
 
-const chainId = base.id
 
 export function BuyTokenBox({
   defaultTokenAmount,
@@ -50,7 +49,11 @@ export function BuyTokenBox({
   const [tokenAmount, _setTokenAmount] = useState((Number(defaultTokenAmount) / 1e18).toString())
   const [tokenAmountBigInt, _setTokenAmountBigInt] = useState(defaultTokenAmount)
 
-  const { balances, refetch } = useERC20Balances([getEthAddress(token)], address)
+  const { balances, refetch } = useERC20Balances(
+    [getEthAddress(token)],
+    address,
+    chainId,
+  )
   const tokenBalance = balances?.[0]
 
   const {
@@ -91,6 +94,7 @@ export function BuyTokenBox({
                 }}
                 currentToken={token}
                 currentTokenEmitter={tokenEmitter}
+                chainId={chainId}
               />
             </div>
             <TokenBalanceAndUSDValue

--- a/web/app/token/buy-token-button.tsx
+++ b/web/app/token/buy-token-button.tsx
@@ -7,11 +7,9 @@ import { useWaitForTransactions } from "@/lib/wagmi/use-wait-for-transactions"
 import type { ComponentProps, PropsWithChildren } from "react"
 import { toast } from "sonner"
 import { type Address, zeroAddress } from "viem"
-import { base } from "viem/chains"
 import { useAccount, useBalance } from "wagmi"
 import { useBuyTokenRelay } from "./hooks/use-buy-token-relay"
 
-const toChainId = base.id
 
 interface Props extends ComponentProps<typeof Button> {
   onSuccess: (hash: string) => void
@@ -76,7 +74,7 @@ export const BuyTokenButton = ({
             },
           ]
 
-          const useRelay = chainId !== toChainId
+          const useRelay = selectedChain.id !== chainId
 
           if (useRelay) {
             executeBuyTokenRelay({

--- a/web/app/token/sell-token-box.tsx
+++ b/web/app/token/sell-token-box.tsx
@@ -3,7 +3,6 @@
 import { getEthAddress } from "@/lib/utils"
 import { useState } from "react"
 import type { Address } from "viem"
-import { base } from "viem/chains"
 import { useAccount, useBalance } from "wagmi"
 import { useSellTokenQuote } from "./hooks/use-sell-token-quote"
 import { formatUSDValue, useETHPrice } from "./hooks/useETHPrice"
@@ -28,9 +27,9 @@ interface Props {
   tokenEmitter: Address
   onSuccess: (hash: string) => void
   setTokenAndEmitter: (token: Address, tokenEmitter: Address) => void
+  chainId: number
 }
 
-const chainId = base.id
 
 export function SellTokenBox(props: Props) {
   const {
@@ -41,13 +40,18 @@ export function SellTokenBox(props: Props) {
     parentFlowContract,
     setTokenAndEmitter,
     onSuccess,
+    chainId,
   } = props
   const { address } = useAccount()
   const { data: balance } = useBalance({ address })
   const [tokenAmount, _setTokenAmount] = useState((Number(defaultTokenAmount) / 1e18).toString())
   const [tokenAmountBigInt, _setTokenAmountBigInt] = useState(defaultTokenAmount)
 
-  const { balances, refetch } = useERC20Balances([getEthAddress(token)], address)
+  const { balances, refetch } = useERC20Balances(
+    [getEthAddress(token)],
+    address,
+    chainId,
+  )
   const tokenBalance = balances?.[0]
 
   const { tokens, refetch: refetchTokens } = useERC20Tokens([token], chainId)
@@ -85,6 +89,7 @@ export function SellTokenBox(props: Props) {
                 }}
                 currentToken={token}
                 currentTokenEmitter={tokenEmitter}
+                chainId={chainId}
               />
             </div>
             <div className="flex items-center justify-between">
@@ -134,6 +139,7 @@ export function SellTokenBox(props: Props) {
         tokenBalance={tokenBalance}
         tokenAmountBigInt={tokenAmountBigInt}
         payment={BigInt(payment)}
+        chainId={chainId}
         onSuccess={(hash) => {
           refetch()
           refetchTokens()

--- a/web/app/token/sell-token-button.tsx
+++ b/web/app/token/sell-token-button.tsx
@@ -2,11 +2,8 @@ import { Button } from "@/components/ui/button"
 import { tokenEmitterImplAbi } from "@/lib/abis"
 import { useContractTransaction } from "@/lib/wagmi/use-contract-transaction"
 import { Address } from "viem"
-import { base } from "viem/chains"
 import { useAccount } from "wagmi"
 import { toast } from "sonner"
-
-const chainId = base.id
 
 export const SellTokenButton = ({
   isLoadingQuote,
@@ -17,6 +14,7 @@ export const SellTokenButton = ({
   onSuccess,
   tokenSymbol,
   tokenEmitter,
+  chainId,
 }: {
   isLoadingQuote: boolean
   tokenBalance: bigint
@@ -26,6 +24,7 @@ export const SellTokenButton = ({
   onSuccess: (hash: string) => void
   tokenSymbol: string
   tokenEmitter: Address
+  chainId: number
 }) => {
   const { address } = useAccount()
   const { prepareWallet, writeContract, toastId, isLoading } = useContractTransaction({

--- a/web/app/token/swap-token-box.tsx
+++ b/web/app/token/swap-token-box.tsx
@@ -50,6 +50,7 @@ export function SwapTokenBox(props: Props) {
             onSuccess={onSuccess}
             parentFlowContract={parentFlowContract}
             defaultTokenAmount={defaultTokenAmount}
+            chainId={flow.chainId}
             switchSwapBox={() => setSwapState("sell")}
             setTokenAndEmitter={(token, tokenEmitter) => {
               setToken(token)
@@ -63,6 +64,7 @@ export function SwapTokenBox(props: Props) {
             onSuccess={onSuccess}
             parentFlowContract={parentFlowContract}
             defaultTokenAmount={defaultTokenAmount}
+            chainId={flow.chainId}
             switchSwapBox={() => setSwapState("buy")}
             setTokenAndEmitter={(token, tokenEmitter) => {
               setToken(token)

--- a/web/app/token/swap-token-button.tsx
+++ b/web/app/token/swap-token-button.tsx
@@ -42,7 +42,11 @@ export function SwapTokenButton(props: Props) {
   const ref = useRef<HTMLButtonElement>(null)
   const isRemoved = flow.isRemoved
 
-  const { balances, refetch } = useERC20Balances([erc20Address], address)
+  const { balances, refetch } = useERC20Balances(
+    [erc20Address],
+    address,
+    flow.chainId,
+  )
   const {
     onSuccess = () => {
       // close dialog

--- a/web/app/token/token-list.tsx
+++ b/web/app/token/token-list.tsx
@@ -5,10 +5,12 @@ import { type Address, formatEther } from "viem"
 import { useERC20Balances } from "@/lib/tcr/use-erc20-balances"
 import { formatUSDValue, useETHPrice } from "./hooks/useETHPrice"
 import { useSellTokenQuote } from "./hooks/use-sell-token-quote"
-import { base } from "viem/chains"
 
-const chainId = base.id
-
+interface Props {
+  chainId: number
+  tokens: TokenData[] | undefined
+  switchToken: (token: Address, tokenEmitter: Address) => void
+}
 interface TokenData {
   address: string | undefined
   name: string | undefined
@@ -18,16 +20,12 @@ interface TokenData {
   tokenEmitter: string | undefined
 }
 
-interface TokenListProps {
-  tokens: TokenData[] | undefined
-  switchToken: (token: Address, tokenEmitter: Address) => void
-}
-
-export const TokenList = ({ tokens, switchToken }: TokenListProps) => {
+export const TokenList = ({ tokens, switchToken, chainId }: Props) => {
   const { address: owner } = useAccount()
   const { balances } = useERC20Balances(
     tokens?.map((token) => getEthAddress(token.address as Address)) || [],
     owner,
+    chainId,
   )
   const { ethPrice } = useETHPrice()
 
@@ -58,6 +56,7 @@ export const TokenList = ({ tokens, switchToken }: TokenListProps) => {
           }
           balance={balance}
           ethPrice={ethPrice || 0}
+          chainId={chainId}
         />
       ))}
     </ul>
@@ -70,12 +69,14 @@ const TokenListItem = ({
   ethPrice,
   onClick,
   currentTokenEmitter,
+  chainId,
 }: {
   token: TokenData
   balance: bigint
   ethPrice: number
   onClick: () => void
   currentTokenEmitter: Address | undefined
+  chainId: number
 }) => {
   const { payment } = useSellTokenQuote(getEthAddress(currentTokenEmitter || ""), balance, chainId)
 

--- a/web/app/token/token-switcher-dialog.tsx
+++ b/web/app/token/token-switcher-dialog.tsx
@@ -14,7 +14,6 @@ import { getIpfsUrl } from "@/lib/utils"
 import { ChevronDownIcon } from "@radix-ui/react-icons"
 import { useRef } from "react"
 import type { Address } from "viem"
-import { base } from "viem/chains"
 import { CurrencyDisplay } from "./currency-display"
 import { TokenList } from "./token-list"
 import { TokenLogo } from "./token-logo"
@@ -24,15 +23,15 @@ interface Props {
   currentToken: Address | undefined
   currentTokenEmitter: Address | undefined
   parentFlowContract: Address
+  chainId: number
 }
-
-const chainId = base.id
 
 export function TokenSwitcherDialog({
   switchToken,
   currentToken,
   currentTokenEmitter,
   parentFlowContract,
+  chainId,
 }: Props) {
   const { tokens, isLoading } = useERC20TokensForParent(parentFlowContract, chainId)
   const ref = useRef<HTMLButtonElement>(null)
@@ -65,6 +64,7 @@ export function TokenSwitcherDialog({
               ref.current?.click() // close dialog
             }}
             tokens={tokens}
+            chainId={chainId}
           />
         )}
       </DialogContent>

--- a/web/components/global/add-recipient-to-flow-button.tsx
+++ b/web/components/global/add-recipient-to-flow-button.tsx
@@ -7,7 +7,6 @@ import { useContractTransaction } from "@/lib/wagmi/use-contract-transaction"
 import type { Draft } from "@prisma/flows"
 import { toast } from "sonner"
 import { encodeAbiParameters, keccak256 } from "viem"
-import { base } from "viem/chains"
 import { useAccount } from "wagmi"
 import { publishDraft } from "../../app/draft/[draftId]/publish-draft"
 import { useRouter } from "next/navigation"
@@ -15,14 +14,13 @@ import { useRouter } from "next/navigation"
 interface Props {
   draft: Draft
   contract: `0x${string}`
+  chainId: number
   size?: "default" | "sm"
   onSuccess?: () => void
 }
 
-const chainId = base.id
-
 export function AddRecipientToFlowButton(props: Props) {
-  const { draft, contract, size = "default", onSuccess } = props
+  const { draft, contract, chainId, size = "default", onSuccess } = props
   const { address } = useAccount()
   const router = useRouter()
 

--- a/web/components/global/grants-table.tsx
+++ b/web/components/global/grants-table.tsx
@@ -137,6 +137,7 @@ export function GrantsTable(props: Props) {
                     <RemoveRecipientButton
                       contract={flow.recipient}
                       recipientId={grant.recipientId}
+                      chainId={flow.chainId}
                     />
                   )}
                 </div>

--- a/web/components/global/hooks/use-bulk-pool-withdraw-macro.ts
+++ b/web/components/global/hooks/use-bulk-pool-withdraw-macro.ts
@@ -3,13 +3,15 @@ import { BULK_WITHDRAW_MACRO, MACRO_FORWARDER } from "@/lib/config"
 import { useContractTransaction } from "@/lib/wagmi/use-contract-transaction"
 import { toast } from "sonner"
 import { encodeAbiParameters } from "viem"
-import { base } from "viem/chains"
 import { useAccount } from "wagmi"
 import { useUserTcrTokens } from "../curator-popover/hooks/use-user-tcr-tokens"
 
-export const useBulkPoolWithdrawMacro = (pools: `0x${string}`[], onSuccess?: () => void) => {
+export const useBulkPoolWithdrawMacro = (
+  pools: `0x${string}`[],
+  chainId: number,
+  onSuccess?: () => void,
+) => {
   const { address } = useAccount()
-  const chainId = base.id
   const { mutateEarnings } = useUserTcrTokens(address)
 
   const { prepareWallet, writeContract, isLoading, toastId } = useContractTransaction({

--- a/web/components/global/remove-recipient-button.tsx
+++ b/web/components/global/remove-recipient-button.tsx
@@ -3,17 +3,18 @@
 import { useRemoveRecipient } from "@/lib/onchain-startup/use-remove-recipient"
 import { Button } from "../ui/button"
 import { Trash } from "lucide-react"
-import { base } from "viem/chains"
 import { getAddress } from "viem"
 
 export const RemoveRecipientButton = ({
   contract,
   recipientId,
+  chainId,
 }: {
   contract: string
   recipientId: string
+  chainId: number
 }) => {
-  const { removeRecipient } = useRemoveRecipient(base.id)
+  const { removeRecipient } = useRemoveRecipient(chainId)
 
   const handleDelete = () => {
     removeRecipient({ recipientId, contract: getAddress(contract) })

--- a/web/components/global/withdraw-curator-salary-button.tsx
+++ b/web/components/global/withdraw-curator-salary-button.tsx
@@ -19,7 +19,7 @@ export const WithdrawCuratorSalaryButton = ({
 }) => {
   const { balance, isLoading, refetch } = useClaimablePoolBalance(pool, user, chainId)
 
-  const { withdraw } = useBulkPoolWithdrawMacro([pool], () => refetch())
+  const { withdraw } = useBulkPoolWithdrawMacro([pool], chainId, () => refetch())
 
   return (
     <Tooltip>

--- a/web/components/global/withdraw-salary-button.tsx
+++ b/web/components/global/withdraw-salary-button.tsx
@@ -23,7 +23,7 @@ export const WithdrawSalaryButton = ({
   onSuccess?: () => void
   chainId: number
 }) => {
-  const { withdraw } = useBulkPoolWithdrawMacro(pools, onSuccess)
+  const { withdraw } = useBulkPoolWithdrawMacro(pools, chainId, onSuccess)
 
   const { balance, isLoading } = useClaimableFlowsBalance(flow, builder, chainId)
 

--- a/web/lib/tcr/use-erc20-balances.tsx
+++ b/web/lib/tcr/use-erc20-balances.tsx
@@ -1,16 +1,19 @@
 import { Address, erc20Abi } from "viem"
-import { base } from "viem/chains"
 import { useReadContracts } from "wagmi"
 import { getEthAddress } from "../utils"
 
-export function useERC20Balances(contracts: Address[], owner: Address | undefined) {
+export function useERC20Balances(
+  contracts: Address[],
+  owner: Address | undefined,
+  chainId: number,
+) {
   const { data, refetch } = useReadContracts({
     contracts: contracts.map((contract) => ({
       abi: erc20Abi,
       address: contract,
       functionName: "balanceOf",
       args: [owner!!],
-      chainId: base.id,
+      chainId,
     })),
     query: { enabled: !!owner },
   })
@@ -23,8 +26,16 @@ export function useERC20Balances(contracts: Address[], owner: Address | undefine
   }
 }
 
-export function useERC20Balance(contract: string, owner: Address | undefined) {
-  const { balances, refetch } = useERC20Balances([getEthAddress(contract)], owner)
+export function useERC20Balance(
+  contract: string,
+  owner: Address | undefined,
+  chainId: number,
+) {
+  const { balances, refetch } = useERC20Balances(
+    [getEthAddress(contract)],
+    owner,
+    chainId,
+  )
 
   return {
     balance: balances[0] || 0n,

--- a/web/lib/tcr/use-erc20s-for-parent.tsx
+++ b/web/lib/tcr/use-erc20s-for-parent.tsx
@@ -1,9 +1,8 @@
 import type { Address } from "viem"
-import { base } from "viem/chains"
 import { useFlowsForParent } from "./use-flows-for-parent"
 import { useERC20Tokens } from "./use-erc20s"
 
-export function useERC20TokensForParent(parentGrantContract: Address, chainId = base.id) {
+export function useERC20TokensForParent(parentGrantContract: Address, chainId: number) {
   const { grants, isLoading: isLoadingFlows } = useFlowsForParent(parentGrantContract)
   const erc20s = grants.map((grant) => grant.erc20 as Address)
 

--- a/web/lib/tcr/use-erc20s.tsx
+++ b/web/lib/tcr/use-erc20s.tsx
@@ -1,8 +1,7 @@
 import { type Address, erc20Abi } from "viem"
-import { base } from "viem/chains"
 import { useReadContracts } from "wagmi"
 
-export function useERC20Tokens(tokens: Address[], chainId = base.id) {
+export function useERC20Tokens(tokens: Address[], chainId: number) {
   const erc20s = tokens.map((token) => ({
     abi: erc20Abi,
     address: token as Address,

--- a/web/lib/tcr/use-tcr-data.tsx
+++ b/web/lib/tcr/use-tcr-data.tsx
@@ -1,11 +1,10 @@
 "use client"
 
 import { Address } from "viem"
-import { base } from "viem/chains"
 import { useReadContracts } from "wagmi"
 import { flowTcrImplAbi } from "../abis"
 
-export function useTcrData(contract: Address | undefined, chainId = base.id) {
+export function useTcrData(contract: Address | undefined, chainId: number) {
   const tcr = { abi: flowTcrImplAbi, address: contract, chainId }
 
   const { data } = useReadContracts({

--- a/web/lib/tcr/use-tcr-token.tsx
+++ b/web/lib/tcr/use-tcr-token.tsx
@@ -2,13 +2,12 @@
 
 import { useContractTransaction } from "@/lib/wagmi/use-contract-transaction"
 import { Address } from "viem"
-import { base } from "viem/chains"
 import { useAccount } from "wagmi"
 import { erc20VotesMintableImplAbi } from "../abis"
 import { getTokenData } from "./get-token-data"
 import { useServerFunction } from "../hooks/use-server-function"
 
-export function useTcrToken(contract: Address, spender: Address, chainId = base.id, skip = false) {
+export function useTcrToken(contract: Address, spender: Address, chainId: number, skip = false) {
   const { address: owner } = useAccount()
 
   const { data, mutate } = useServerFunction(getTokenData, skip ? undefined : "token-data", [


### PR DESCRIPTION
## Summary
- allow passing chainId through components
- remove hardcoded `base.id` defaults in many hooks/components

## Testing
- `pnpm lint && pnpm typecheck` *(fails: Parameter implicitly has any type)*
- `pnpm build` *(fails: binaries.prisma.sh 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6859f93ec97883278ec04cb28bb47f75