### PR TITLE
fix: derive chain from db

### DIFF
--- a/web/app/chat/components/tools/request-grant-removal.tsx
+++ b/web/app/chat/components/tools/request-grant-removal.tsx
@@ -14,7 +14,6 @@ import { useContractTransaction } from "@/lib/wagmi/use-contract-transaction"
 import type { PropsWithChildren } from "react"
 import { toast } from "sonner"
 import { formatEther } from "viem"
-import { base } from "viem/chains"
 import { useAccount } from "wagmi"
 import { useAgentChat } from "../agent-chat"
 
@@ -32,7 +31,7 @@ export function RequestGrantRemoval(props: Props) {
   const { address } = useAccount()
   const { user, append } = useAgentChat()
 
-  const chainId = grant?.flow.chainId ?? grant?.chainId ?? base.id
+  const chainId = grant?.flow.chainId ?? grant?.chainId
 
   const { removeItemCost, challengePeriodFormatted } = useTcrData(
     grant?.flow.tcr as `0x${string}`,

--- a/web/app/components/dispute/dispute-execute.tsx
+++ b/web/app/components/dispute/dispute-execute.tsx
@@ -11,7 +11,6 @@ import { canDisputeBeExecuted } from "@/app/components/dispute/helpers"
 import { useContractTransaction } from "@/lib/wagmi/use-contract-transaction"
 import { Dispute } from "@prisma/flows"
 import { useRouter } from "next/navigation"
-import { base } from "viem/chains"
 
 interface Props {
   arbitrator: `0x${string}`
@@ -54,7 +53,7 @@ export function DisputeExecuteButton(props: Props) {
           ],
           functionName: "executeRuling",
           args: [BigInt(dispute.disputeId)],
-          chainId: base.id,
+          chainId,
         })
       }}
     >

--- a/web/app/components/dispute/dispute-user-vote.tsx
+++ b/web/app/components/dispute/dispute-user-vote.tsx
@@ -11,7 +11,6 @@ import { useRouter } from "next/navigation"
 import { useEffect, useState } from "react"
 import { toast } from "sonner"
 import { formatEther } from "viem"
-import { base } from "viem/chains"
 import { useSecretVoteHash } from "./useSecretVoteHash"
 import type { User } from "@/lib/auth/user"
 import { AuthButton } from "@/components/ui/auth-button"
@@ -109,7 +108,7 @@ export function DisputeUserVote(props: Props) {
                 abi: erc20VotesArbitratorImplAbi,
                 functionName: "commitVote",
                 args: [BigInt(dispute.disputeId), mirrored ? againstCommitHash : forCommitHash],
-                chainId: base.id,
+                chainId: grant.chainId,
               })
             } catch (e: any) {
               toast.error(e.message, { id: toastId })
@@ -138,7 +137,7 @@ export function DisputeUserVote(props: Props) {
                 abi: erc20VotesArbitratorImplAbi,
                 functionName: "commitVote",
                 args: [BigInt(dispute.disputeId), mirrored ? forCommitHash : againstCommitHash],
-                chainId: base.id,
+                chainId: grant.chainId,
               })
             } catch (e: any) {
               toast.error(e.message, { id: toastId })

--- a/web/app/components/dispute/request-execute.tsx
+++ b/web/app/components/dispute/request-execute.tsx
@@ -9,7 +9,6 @@ import type { Grant } from "@prisma/flows"
 import { useRouter } from "next/navigation"
 import { toast } from "sonner"
 import type { Address } from "viem"
-import { base } from "viem/chains"
 
 interface Props {
   grant: Omit<Grant, "description">
@@ -50,7 +49,7 @@ export function RequestExecuteButton(props: Props) {
           abi: [...flowTcrImplAbi, ...nounsFlowImplAbi, ...erc20VotesMintableImplAbi],
           functionName: "executeRequest",
           args: [grant.id as Address],
-          chainId: base.id,
+          chainId: flow.chainId,
         })
       }}
     >

--- a/web/app/components/dispute/useVotingReceipt.ts
+++ b/web/app/components/dispute/useVotingReceipt.ts
@@ -1,13 +1,18 @@
 import { erc20VotesArbitratorImplAbi } from "@/lib/abis"
 import { Address } from "viem"
-import { base } from "viem/chains"
+
 import { useReadContract } from "wagmi"
 
-export function useVotingReceipt(arbitratorContract: Address, disputeId: string, voter?: Address) {
+export function useVotingReceipt(
+  arbitratorContract: Address,
+  disputeId: string,
+  chainId: number,
+  voter?: Address,
+) {
   const { data: receipt } = useReadContract({
     abi: erc20VotesArbitratorImplAbi,
     address: arbitratorContract,
-    chainId: base.id,
+    chainId,
     functionName: "getReceipt",
     args: [BigInt(disputeId), voter as Address],
     query: { enabled: !!voter },

--- a/web/app/crons/balance-flow-rates/route.ts
+++ b/web/app/crons/balance-flow-rates/route.ts
@@ -1,10 +1,10 @@
 import { NextResponse } from "next/server"
 import { getBalanceFlowRatesWalletClient } from "@/lib/viem/walletClient"
 import { NOUNS_FLOW } from "@/lib/config"
-import { base } from "viem/chains"
 import { waitForTransactionReceipt } from "viem/actions"
 import { nounsFlowImplAbi } from "@/lib/abis"
 import { getContract } from "viem"
+import database from "@/lib/database/flows-db"
 import { getClient } from "@/lib/viem/client"
 
 export const dynamic = "force-dynamic"
@@ -13,15 +13,19 @@ export const maxDuration = 300
 
 export async function GET() {
   try {
-    // hardcoded to base because this is only for Nouns Flow
-    const client = getBalanceFlowRatesWalletClient(base.id)
+    const { chainId } = await database.grant.findFirstOrThrow({
+      where: { id: NOUNS_FLOW },
+      select: { chainId: true },
+    })
+
+    const client = getBalanceFlowRatesWalletClient(chainId)
 
     let nUpdated = 0
 
     const contract = getContract({
       address: NOUNS_FLOW,
       abi: nounsFlowImplAbi,
-      client: getClient(base.id),
+      client: getClient(chainId),
     })
 
     // Read the number of child flows that are out of sync

--- a/web/app/crons/flow-rate-too-high/route.ts
+++ b/web/app/crons/flow-rate-too-high/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from "next/server"
 import { getBalanceFlowRatesWalletClient } from "@/lib/viem/walletClient"
 import { NOUNS_FLOW } from "@/lib/config"
-import { base } from "viem/chains"
 import { waitForTransactionReceipt } from "viem/actions"
 import { customFlowImplAbi } from "@/lib/abis"
 import { getContract } from "viem"
@@ -14,8 +13,6 @@ export const maxDuration = 300
 
 export async function GET() {
   try {
-    const client = getBalanceFlowRatesWalletClient(base.id)
-
     const flows = await database.grant.findMany({
       where: {
         isFlow: true,
@@ -26,8 +23,10 @@ export async function GET() {
 
     let nUpdated = 0
 
-    // Check each flow to see if it's too high and decrease if needed
+    // Process each flow using its chainId
     for (const flow of flows) {
+      const client = getBalanceFlowRatesWalletClient(flow.chainId)
+
       try {
         const contract = getContract({
           address: flow.id as `0x${string}`,

--- a/web/app/dashboard/[id]/components/money-flow-diagram.tsx
+++ b/web/app/dashboard/[id]/components/money-flow-diagram.tsx
@@ -10,7 +10,6 @@ import { Background, MarkerType, type Node, Position, ReactFlow } from "@xyflow/
 import "@xyflow/react/dist/style.css"
 import Image from "next/image"
 import Link from "next/link"
-import { base } from "viem/chains"
 import { JoinStartupLink } from "./join-startup-link"
 import { TokenDAOLink } from "./token-dao-link"
 import { BuyRevnetToken } from "./nodes/buy-revnet-token"
@@ -50,7 +49,7 @@ export function MoneyFlowDiagram(props: Props) {
     tokenVolume,
     setTokenVolumeEth,
     totalRevnetTokens,
-  } = useFundraiseIllustration(startup.revnetProjectIds.base)
+  } = useFundraiseIllustration(startup.revnetProjectIds.base, startup.chainId)
 
   // return <MoneyFlowSkeleton />
   if (!width)
@@ -121,13 +120,14 @@ export function MoneyFlowDiagram(props: Props) {
         row: 1,
         height: 320,
         id: "user_action",
-        title: <ProductsTitle startup={startup} chainId={base.id} />,
+        title: <ProductsTitle startup={startup} chainId={startup.chainId} />,
         className: "bg-background dark:bg-background/50 shadow",
         content: (
           <ProductsList
             changeProductsVolumeEth={(eth) => setProductsVolumeEth(eth)}
             products={products.slice(0, 10)}
             startup={startup}
+            chainId={startup.chainId}
           />
         ),
         handles: isMobile ? [] : [{ type: "source", position: Position.Right }],
@@ -139,7 +139,7 @@ export function MoneyFlowDiagram(props: Props) {
           <JoinStartupLink
             startupTitle={startup.title}
             projectId={startup.revnetProjectIds.base}
-            chainId={base.id}
+            chainId={startup.chainId}
           />
         ),
         id: "user_token",
@@ -148,6 +148,7 @@ export function MoneyFlowDiagram(props: Props) {
           <BuyRevnetToken
             projectId={startup.revnetProjectIds.base}
             changeTokenVolumeEth={(eth) => setTokenVolumeEth(eth)}
+            chainId={startup.chainId}
           />
         ),
         handles: isMobile ? [] : [{ type: "source", position: Position.Right }],
@@ -179,12 +180,14 @@ export function MoneyFlowDiagram(props: Props) {
         title: (
           <TreasuryTitle
             startup={startup}
-            chainId={base.id}
+            chainId={startup.chainId}
             ethRaised={productsVolumeEth + tokenVolume}
           />
         ),
         height: 90,
-        content: <Treasury projectId={startup.revnetProjectIds.base} chainId={base.id} />,
+        content: (
+          <Treasury projectId={startup.revnetProjectIds.base} chainId={startup.chainId} />
+        ),
       },
       {
         col: 3,
@@ -231,7 +234,7 @@ export function MoneyFlowDiagram(props: Props) {
           <TokenDAOLink
             startupTitle={startup.title}
             projectId={startup.revnetProjectIds.base}
-            chainId={base.id}
+            chainId={startup.chainId}
             tokenAmount={Number(totalRevnetTokens)}
           />
         ),
@@ -240,7 +243,7 @@ export function MoneyFlowDiagram(props: Props) {
         content: (
           <TokenRewards
             projectId={startup.revnetProjectIds.base}
-            chainId={base.id}
+            chainId={startup.chainId}
             userAddress={user?.address}
             extraRevnetTokens={totalRevnetTokens}
             startupTitle={startup.title}

--- a/web/app/dashboard/[id]/components/nodes/buy-revnet-token.tsx
+++ b/web/app/dashboard/[id]/components/nodes/buy-revnet-token.tsx
@@ -5,7 +5,6 @@ import { Label } from "@/components/ui/label"
 import { usePayRevnet } from "@/lib/revnet/hooks/use-pay-revnet"
 import { useRevnetTokenPrice } from "@/lib/revnet/hooks/use-revnet-token-price"
 import { useRevnetTokenDetails } from "@/lib/revnet/hooks/use-revnet-token-details"
-import { base } from "viem/chains"
 import { useAccount } from "wagmi"
 import { useEffect, useState } from "react"
 import { AuthButton } from "@/components/ui/auth-button"
@@ -14,17 +13,18 @@ import { ArrowDown } from "lucide-react"
 interface Props {
   projectId: bigint
   changeTokenVolumeEth: (eth: number) => void
+  chainId: number
 }
 
-export function BuyRevnetToken({ projectId, changeTokenVolumeEth }: Props) {
+export function BuyRevnetToken({ projectId, changeTokenVolumeEth, chainId }: Props) {
   const { address } = useAccount()
-  const { payRevnet, isLoading } = usePayRevnet(base.id)
+  const { payRevnet, isLoading } = usePayRevnet(chainId)
   const {
     isLoading: isPriceLoading,
     calculateTokensFromEth,
     calculateEthFromTokens,
-  } = useRevnetTokenPrice(projectId, base.id)
-  const { data: tokenDetails } = useRevnetTokenDetails(projectId, base.id)
+  } = useRevnetTokenPrice(projectId, chainId)
+  const { data: tokenDetails } = useRevnetTokenDetails(projectId, chainId)
   const [payAmount, setPayAmount] = useState("0.01")
   const [tokenAmount, setTokenAmount] = useState("")
   const [lastEdited, setLastEdited] = useState<"pay" | "token">("pay")

--- a/web/app/dashboard/[id]/components/nodes/products-list.tsx
+++ b/web/app/dashboard/[id]/components/nodes/products-list.tsx
@@ -5,7 +5,6 @@ import { Input } from "@/components/ui/input"
 import { Startup } from "@/lib/onchain-startup/startup"
 import { useRevnetTokenPrice } from "@/lib/revnet/hooks/use-revnet-token-price"
 import { useRevnetTokenDetails } from "@/lib/revnet/hooks/use-revnet-token-details"
-import { base } from "viem/chains"
 import { useEffect, useState } from "react"
 import { Minus, Plus } from "lucide-react"
 
@@ -13,15 +12,16 @@ interface Props {
   changeProductsVolumeEth: (eth: number) => void
   products: Array<{ name: string; image: string; url: string }>
   startup: Startup
+  chainId: number
 }
 
 export function ProductsList(props: Props) {
-  const { changeProductsVolumeEth, products, startup } = props
+  const { changeProductsVolumeEth, products, startup, chainId } = props
   const [quantity, setQuantity] = useState("1")
   const [touched, setTouched] = useState(false)
   const projectId = startup.revnetProjectId
-  const { calculateTokensFromEth } = useRevnetTokenPrice(BigInt(projectId), base.id)
-  const { data: tokenDetails } = useRevnetTokenDetails(BigInt(projectId), base.id)
+  const { calculateTokensFromEth } = useRevnetTokenPrice(BigInt(projectId), chainId)
+  const { data: tokenDetails } = useRevnetTokenDetails(BigInt(projectId), chainId)
 
   const tokenSymbol = tokenDetails?.symbol || ""
   const quantityNum = quantity === "" ? 0 : parseInt(quantity)

--- a/web/app/dashboard/[id]/components/sales-overview.tsx
+++ b/web/app/dashboard/[id]/components/sales-overview.tsx
@@ -10,13 +10,14 @@ import {
 } from "@/components/ui/chart"
 import { MonthlySales } from "@/lib/shopify/summary"
 import { Bar, CartesianGrid, ComposedChart, Line, XAxis, YAxis } from "recharts"
-import { base } from "viem/chains"
+
 import { BringRevenueOnchain } from "./bring-revenue-onchain"
 
 interface Props {
   monthlySales: MonthlySales[]
   startupTitle: string
   projectId: bigint
+  chainId: number
 }
 
 const chartConfig = {
@@ -25,7 +26,7 @@ const chartConfig = {
 } as const
 
 export function SalesOverview(props: Props) {
-  const { monthlySales, startupTitle, projectId } = props
+  const { monthlySales, startupTitle, projectId, chainId } = props
 
   return (
     <Card className="border border-border/40 bg-card/80 shadow-sm">
@@ -38,7 +39,7 @@ export function SalesOverview(props: Props) {
           <BringRevenueOnchain
             startupTitle={startupTitle}
             projectId={projectId}
-            chainId={base.id}
+            chainId={chainId}
           />
         </div>
       </CardHeader>

--- a/web/app/dashboard/[id]/components/timeline/token-event.tsx
+++ b/web/app/dashboard/[id]/components/timeline/token-event.tsx
@@ -34,6 +34,7 @@ export async function TokenEvent({ payment, date }: Props) {
               address={payment.payer as `0x${string}`}
               username={payerProfile.username}
               className="font-medium text-foreground hover:text-primary"
+              chainId={payment.chainId}
             >
               {payerProfile.display_name}
             </ProfileLink>{" "}
@@ -45,6 +46,7 @@ export async function TokenEvent({ payment, date }: Props) {
                   address={beneficiary as `0x${string}`}
                   username={beneficiaryProfile.username}
                   className="font-medium text-foreground hover:text-primary"
+                  chainId={payment.chainId}
                 >
                   {beneficiaryProfile.username}
                 </ProfileLink>

--- a/web/app/dashboard/[id]/hooks/use-fundraise-illustration.ts
+++ b/web/app/dashboard/[id]/hooks/use-fundraise-illustration.ts
@@ -2,13 +2,11 @@
 
 import { useState, useMemo } from "react"
 import { useRevnetTokenPrice } from "@/lib/revnet/hooks/use-revnet-token-price"
-import { base } from "viem/chains"
-
-export function useFundraiseIllustration(projectId: bigint) {
+export function useFundraiseIllustration(projectId: bigint, chainId: number) {
   const [productsVolumeEth, setProductsVolumeEth] = useState(0)
   const [tokenVolume, setTokenVolumeEth] = useState(0)
 
-  const { calculateTokensFromEth } = useRevnetTokenPrice(projectId, base.id)
+  const { calculateTokensFromEth } = useRevnetTokenPrice(projectId, chainId)
 
   const totalRevnetTokens = useMemo(() => {
     if (!projectId) return "0"

--- a/web/app/dashboard/[id]/page.tsx
+++ b/web/app/dashboard/[id]/page.tsx
@@ -116,6 +116,7 @@ export default async function GrantPage(props: Props) {
               monthlySales={salesSummary.monthlySales}
               startupTitle={startup.title}
               projectId={startup.revnetProjectIds.base}
+              chainId={startup.chainId}
             />
           </div>
 

--- a/web/app/flow/[flowId]/components/budget-dialog.tsx
+++ b/web/app/flow/[flowId]/components/budget-dialog.tsx
@@ -10,7 +10,6 @@ import { Currency } from "@/components/ui/currency"
 import type { FlowWithGrants } from "@/lib/database/queries/flow"
 import { explorerUrl } from "@/lib/utils"
 import Link from "next/link"
-import { base } from "viem/chains"
 import { Separator } from "@radix-ui/react-select"
 
 interface Props {
@@ -203,7 +202,7 @@ export const BudgetDialog = (props: Props) => {
 
         <Link
           className="text-base underline"
-          href={explorerUrl(flow.recipient, base.id, "address")}
+          href={explorerUrl(flow.recipient, flow.chainId, "address")}
           target="_blank"
         >
           View on Explorer

--- a/web/app/flow/[flowId]/hooks/useChangeChallengeDuration.ts
+++ b/web/app/flow/[flowId]/hooks/useChangeChallengeDuration.ts
@@ -2,12 +2,11 @@
 
 import { flowTcrImplAbi, nounsFlowImplAbi } from "@/lib/abis"
 import { useContractTransaction } from "@/lib/wagmi/use-contract-transaction"
-import { base } from "viem/chains"
 import { toast } from "sonner"
 
-export function useChangeChallengeDuration(address: `0x${string}`) {
+export function useChangeChallengeDuration(address: `0x${string}`, chainId: number) {
   const { prepareWallet, writeContract, toastId } = useContractTransaction({
-    chainId: base.id,
+    chainId,
     success: "Challenge duration changed successfully",
   })
 
@@ -20,7 +19,7 @@ export function useChangeChallengeDuration(address: `0x${string}`) {
         abi: flowTcrImplAbi,
         functionName: "changeTimeToChallenge",
         args: [BigInt(newDuration)],
-        chainId: base.id,
+        chainId,
       })
     } catch (e: any) {
       toast.error(e.message, { id: toastId })

--- a/web/app/flow/[flowId]/hooks/useSetBaselinePoolPercent.ts
+++ b/web/app/flow/[flowId]/hooks/useSetBaselinePoolPercent.ts
@@ -2,12 +2,11 @@
 
 import { cfav1ForwarderAbi, nounsFlowImplAbi, superfluidPoolAbi } from "@/lib/abis"
 import { useContractTransaction } from "@/lib/wagmi/use-contract-transaction"
-import { base } from "viem/chains"
 import { toast } from "sonner"
 
-export function useSetBaselinePoolPercent(address: `0x${string}`) {
+export function useSetBaselinePoolPercent(address: `0x${string}`, chainId: number) {
   const { prepareWallet, writeContract, toastId } = useContractTransaction({
-    chainId: base.id,
+    chainId,
     success: "Baseline pool percent updated successfully",
   })
 
@@ -20,7 +19,7 @@ export function useSetBaselinePoolPercent(address: `0x${string}`) {
         abi: [...nounsFlowImplAbi, ...superfluidPoolAbi, ...cfav1ForwarderAbi],
         functionName: "setBaselineFlowRatePercent",
         args: [newPercent],
-        chainId: base.id,
+        chainId,
       })
     } catch (e: any) {
       toast.error(e.message, { id: toastId })

--- a/web/app/flow/[flowId]/hooks/useSetFlowImpl.ts
+++ b/web/app/flow/[flowId]/hooks/useSetFlowImpl.ts
@@ -2,12 +2,11 @@
 
 import { nounsFlowImplAbi } from "@/lib/abis"
 import { useContractTransaction } from "@/lib/wagmi/use-contract-transaction"
-import { base } from "viem/chains"
 import { toast } from "sonner"
 
-export function useSetFlowImpl(address: `0x${string}`) {
+export function useSetFlowImpl(address: `0x${string}`, chainId: number) {
   const { prepareWallet, writeContract, toastId } = useContractTransaction({
-    chainId: base.id,
+    chainId,
     success: "Flow implementation set",
   })
 
@@ -20,7 +19,7 @@ export function useSetFlowImpl(address: `0x${string}`) {
         abi: nounsFlowImplAbi,
         functionName: "setFlowImpl",
         args: [newImplementation],
-        chainId: base.id,
+        chainId,
       })
     } catch (e: any) {
       toast.error(e.message, { id: toastId })

--- a/web/app/flow/[flowId]/hooks/useSetFlowRate.ts
+++ b/web/app/flow/[flowId]/hooks/useSetFlowRate.ts
@@ -2,12 +2,11 @@
 
 import { nounsFlowImplAbi } from "@/lib/abis"
 import { useContractTransaction } from "@/lib/wagmi/use-contract-transaction"
-import { base } from "viem/chains"
 import { toast } from "sonner"
 
-export function useSetFlowRate(address: `0x${string}`) {
+export function useSetFlowRate(address: `0x${string}`, chainId: number) {
   const { prepareWallet, writeContract, toastId } = useContractTransaction({
-    chainId: base.id,
+    chainId,
     success: "Flow rate updated successfully",
   })
 
@@ -20,7 +19,7 @@ export function useSetFlowRate(address: `0x${string}`) {
         abi: nounsFlowImplAbi,
         functionName: "setFlowRate",
         args: [BigInt(newFlowRate)],
-        chainId: base.id,
+        chainId,
       })
     } catch (e: any) {
       toast.error(e.message, { id: toastId })

--- a/web/app/flow/[flowId]/hooks/useUpdateVerifier.ts
+++ b/web/app/flow/[flowId]/hooks/useUpdateVerifier.ts
@@ -2,12 +2,11 @@
 
 import { nounsFlowImplAbi } from "@/lib/abis"
 import { useContractTransaction } from "@/lib/wagmi/use-contract-transaction"
-import { base } from "viem/chains"
 import { toast } from "sonner"
 
-export function useUpdateVerifier(address: `0x${string}`) {
+export function useUpdateVerifier(address: `0x${string}`, chainId: number) {
   const { prepareWallet, writeContract, toastId } = useContractTransaction({
-    chainId: base.id,
+    chainId,
     success: "Flow verifier updated successfully",
   })
 
@@ -20,7 +19,7 @@ export function useUpdateVerifier(address: `0x${string}`) {
         abi: nounsFlowImplAbi,
         functionName: "updateVerifier",
         args: [newVerifier],
-        chainId: base.id,
+        chainId,
       })
     } catch (e: any) {
       toast.error(e.message, { id: toastId })

--- a/web/app/flow/[flowId]/hooks/useUpgradeArbitrator.ts
+++ b/web/app/flow/[flowId]/hooks/useUpgradeArbitrator.ts
@@ -2,12 +2,11 @@
 
 import { useContractTransaction } from "@/lib/wagmi/use-contract-transaction"
 import { erc20VotesArbitratorImplAbi, flowTcrImplAbi } from "@/lib/abis"
-import { base } from "viem/chains"
 import { toast } from "sonner"
 
-export const useUpgradeArbitrator = (arbitratorAddress?: `0x${string}`) => {
+export const useUpgradeArbitrator = (arbitratorAddress?: `0x${string}`, chainId?: number) => {
   const { prepareWallet, writeContract, toastId } = useContractTransaction({
-    chainId: base.id,
+    chainId,
     success: "Arbitrator changed successfully",
   })
 
@@ -22,7 +21,7 @@ export const useUpgradeArbitrator = (arbitratorAddress?: `0x${string}`) => {
         abi: erc20VotesArbitratorImplAbi,
         functionName: "upgradeTo",
         args: [arbitrator],
-        chainId: base.id,
+        chainId,
       })
     } catch (e: any) {
       toast.error(e.message, { id: toastId })

--- a/web/app/flow/[flowId]/hooks/useUpgradeTo.ts
+++ b/web/app/flow/[flowId]/hooks/useUpgradeTo.ts
@@ -2,12 +2,11 @@
 
 import { nounsFlowImplAbi } from "@/lib/abis"
 import { useContractTransaction } from "@/lib/wagmi/use-contract-transaction"
-import { base } from "viem/chains"
 import { toast } from "sonner"
 
-export function useUpgradeTo(address: `0x${string}`) {
+export function useUpgradeTo(address: `0x${string}`, chainId: number) {
   const { prepareWallet, writeContract, toastId } = useContractTransaction({
-    chainId: base.id,
+    chainId,
     success: "Flow implementation upgraded successfully",
   })
 
@@ -20,7 +19,7 @@ export function useUpgradeTo(address: `0x${string}`) {
         abi: nounsFlowImplAbi,
         functionName: "upgradeTo",
         args: [newImplementation],
-        chainId: base.id,
+        chainId,
       })
     } catch (e: any) {
       toast.error(e.message, { id: toastId })

--- a/web/app/flow/[flowId]/hooks/useUpgradeTokenEmitter.ts
+++ b/web/app/flow/[flowId]/hooks/useUpgradeTokenEmitter.ts
@@ -2,12 +2,14 @@
 
 import { useContractTransaction } from "@/lib/wagmi/use-contract-transaction"
 import { tokenEmitterImplAbi } from "@/lib/abis"
-import { base } from "viem/chains"
 import { toast } from "sonner"
 
-export const useUpgradeTokenEmitter = (tokenEmitterAddress?: `0x${string}`) => {
+export const useUpgradeTokenEmitter = (
+  tokenEmitterAddress?: `0x${string}`,
+  chainId?: number,
+) => {
   const { prepareWallet, writeContract, toastId } = useContractTransaction({
-    chainId: base.id,
+    chainId,
     success: "Token emitter changed successfully",
   })
 
@@ -22,7 +24,7 @@ export const useUpgradeTokenEmitter = (tokenEmitterAddress?: `0x${string}`) => {
         abi: tokenEmitterImplAbi,
         functionName: "upgradeTo",
         args: [tokenEmitter],
-        chainId: base.id,
+        chainId,
       })
     } catch (e: any) {
       toast.error(e.message, { id: toastId })

--- a/web/components/user-profile/profile-link.tsx
+++ b/web/components/user-profile/profile-link.tsx
@@ -1,18 +1,18 @@
 import { cn, explorerUrl } from "@/lib/utils"
-import { base } from "viem/chains"
 
 interface ProfileLinkProps {
   username?: string
   address: `0x${string}`
   children: React.ReactNode
   className?: string
+  chainId: number
 }
 
-export function ProfileLink({ username, address, children, className }: ProfileLinkProps) {
+export function ProfileLink({ username, address, children, className, chainId }: ProfileLinkProps) {
   return (
     <a
       href={
-        username ? `https://farcaster.xyz/${username}` : explorerUrl(address, base.id, "address")
+        username ? `https://farcaster.xyz/${username}` : explorerUrl(address, chainId, "address")
       }
       className={cn("text-muted-foreground transition-colors hover:text-foreground", className)}
       target="_blank"

--- a/web/lib/allocation/owner-proofs/proofs.ts
+++ b/web/lib/allocation/owner-proofs/proofs.ts
@@ -1,12 +1,15 @@
 import { NOUNS_TOKEN } from "@/lib/config"
 import { getClient } from "@/lib/viem/client"
-import { base, mainnet } from "viem/chains"
+import { mainnet } from "viem/chains"
 import { encodeAbiParameters, keccak256, PublicClient, toHex, type Address } from "viem"
 import { getBeaconBlock } from "./get-beacon-block"
 import { getBeaconRootAndL2Timestamp } from "./get-beacon-root-and-l2-timestamp"
 import { getExecutionStateRootProof } from "./get-execution-state-root-proof"
 
-export async function generateOwnerProofs(tokens: { id: bigint; owner: Address }[]) {
+export async function generateOwnerProofs(
+  tokens: { id: bigint; owner: Address }[],
+  chainId: number,
+) {
   try {
     const delegators = Array.from(new Set(tokens.map((token) => token.owner)))
     const tokenIdsByOwner = delegators.map((owner) =>
@@ -21,7 +24,7 @@ export async function generateOwnerProofs(tokens: { id: bigint; owner: Address }
     // Step 1: Get the latest beacon root and L2 timestamp
     // This function retrieves the parentBeaconBlockRoot and timestamp from the latest L2 block
     const beaconInfo = await getBeaconRootAndL2Timestamp(
-      getClient(base.id) as PublicClient,
+      getClient(chainId) as PublicClient,
     )
 
     // Step 2: Fetch the beacon block using the beacon root


### PR DESCRIPTION
## Summary
- use chainId from db for flow-rate cron tasks
- update buy revnet token node to accept chainId
- pass chainId through money flow diagram
- link to explorer using grant chainId
- generate owner proofs for any chain

## Testing
- `pnpm lint && pnpm typecheck` *(fails: cannot find modules)*
- `pnpm build` *(fails: could not fetch prisma engine)*


------
https://chatgpt.com/codex/tasks/task_e_685a0ad4063c8327948b4f0a2686cab6