### PR TITLE
fix: include empty bytes for single allocator

### DIFF
--- a/web/lib/allocation/allocation-data/build-data.ts
+++ b/web/lib/allocation/allocation-data/build-data.ts
@@ -43,9 +43,10 @@ export const buildAllocationData = async (
           tokenIds?.map((id) => encodeAbiParameters([{ type: "uint256" }], [BigInt(id)])) || [],
         )
         break
-      case StrategyKey.SingleAllocator:
-        // SingleAllocator doesn't require any data in the JSON
-        allocationData.push([])
+        case StrategyKey.SingleAllocator:
+        // SingleAllocator expects a single empty bytes value so that
+        // the contract computes the allocation key for the caller
+        allocationData.push(["0x"])
         break
       default:
         allocationData.push([])


### PR DESCRIPTION
## Summary
- pass a placeholder `0x` value when building allocationData for SingleAllocator

## Testing
- `pnpm lint && pnpm typecheck`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_685a1d06e4e88327b719d9e06e1c2280