### PR TITLE
feat: track root contract for grants

### DIFF
--- a/indexer/ponder.schema.ts
+++ b/indexer/ponder.schema.ts
@@ -9,6 +9,7 @@ export const grants = onchainTable(
     flowId: t.text().notNull(),
     submitter: t.text().notNull(),
     parentContract: t.text().notNull(),
+    rootContract: t.text().notNull(),
     isTopLevel: t.boolean().notNull(),
     isFlow: t.boolean().notNull(),
     title: t.text().notNull(),
@@ -75,6 +76,7 @@ export const grants = onchainTable(
     recipientIdx: index().on(table.recipient),
     recipientIsFlowIdx: index().on(table.recipient, table.isFlow),
     recipientParentContractIdx: index().on(table.recipient, table.parentContract),
+    rootContractIdx: index().on(table.rootContract),
     recipientManagerRewardPoolIdx: index().on(table.recipient, table.managerRewardPool),
     tcrIsFlowCompoundIdx: index().on(table.tcr, table.isFlow),
     parentContractIsActiveIsRemovedIdx: index().on(

--- a/indexer/src/grants/flow-initialized/custom-flow-initialized.ts
+++ b/indexer/src/grants/flow-initialized/custom-flow-initialized.ts
@@ -7,6 +7,7 @@ import {
   grants,
   parentFlowToChildren,
 } from "ponder:schema"
+import { calculateRootContract } from "../grant-helpers"
 import { getFlowMetadataAndRewardPool } from "./initialized-helpers"
 import { accelerators, customFlows } from "../../../addresses"
 import { isAccelerator } from "../recipients/helpers"
@@ -46,6 +47,11 @@ async function handleFlowInitialized(params: {
   const grantId = contract
 
   const isTopLevel = parentContract === zeroAddress
+  const rootContract = await calculateRootContract(
+    context.db,
+    contract,
+    parentContract
+  )
 
   await context.db.insert(grants).values({
     id: grantId,
@@ -60,6 +66,7 @@ async function handleFlowInitialized(params: {
     isFlow: true,
     isRemoved: false,
     parentContract,
+    rootContract,
     managerRewardPool: managerRewardPool.toLowerCase(),
     managerRewardSuperfluidPool: managerRewardSuperfluidPool.toLowerCase(),
     superToken: superToken.toLowerCase(),

--- a/indexer/src/grants/flow-initialized/nouns-child-flow-initialized.ts
+++ b/indexer/src/grants/flow-initialized/nouns-child-flow-initialized.ts
@@ -11,6 +11,7 @@ import { mainnet as mainnetContracts } from "../../../addresses"
 import { Status } from "../../enums"
 import { isAccelerator } from "../recipients/helpers"
 import { getFlowMetadataAndRewardPool } from "./initialized-helpers"
+import { calculateRootContract } from "../grant-helpers"
 
 ponder.on("NounsFlowChildren:FlowInitialized", handleFlowInitialized)
 
@@ -42,6 +43,11 @@ async function handleFlowInitialized(params: {
 
   // This is because the top level flow has no parent flow contract
   const grantId = contract
+  const rootContract = await calculateRootContract(
+    context.db,
+    contract,
+    parentContract
+  )
 
   await context.db.insert(grants).values({
     id: grantId,
@@ -55,6 +61,7 @@ async function handleFlowInitialized(params: {
     isFlow: true,
     isRemoved: false,
     parentContract,
+    rootContract,
     managerRewardPool: managerRewardPool.toLowerCase(),
     managerRewardSuperfluidPool: managerRewardSuperfluidPool.toLowerCase(),
     superToken: superToken.toLowerCase(),

--- a/indexer/src/grants/flow-initialized/nouns-flow-initialized.ts
+++ b/indexer/src/grants/flow-initialized/nouns-flow-initialized.ts
@@ -15,6 +15,7 @@ import {
 import { getFlowMetadataAndRewardPool } from "./initialized-helpers"
 import { mainnet } from "viem/chains"
 import { isAccelerator } from "../recipients/helpers"
+import { calculateRootContract } from "../grant-helpers"
 
 ponder.on("NounsFlow:FlowInitialized", handleFlowInitialized)
 
@@ -46,6 +47,11 @@ async function handleFlowInitialized(params: {
 
   // This is because the top level flow has no parent flow contract
   const grantId = contract
+  const rootContract = await calculateRootContract(
+    context.db,
+    contract,
+    parentContract
+  )
 
   await context.db.insert(grants).values({
     id: grantId,
@@ -59,6 +65,7 @@ async function handleFlowInitialized(params: {
     isFlow: true,
     isRemoved: false,
     parentContract,
+    rootContract,
     managerRewardPool: managerRewardPool.toLowerCase(),
     managerRewardSuperfluidPool: managerRewardSuperfluidPool.toLowerCase(),
     superToken: superToken.toLowerCase(),

--- a/indexer/src/grants/grant-helpers.ts
+++ b/indexer/src/grants/grant-helpers.ts
@@ -1,5 +1,6 @@
 import { Context } from "ponder:registry"
-import { flowContractAndRecipientIdToGrantId } from "ponder:schema"
+import { grants, flowContractAndRecipientIdToGrantId } from "ponder:schema"
+import { zeroAddress } from "viem"
 
 export async function addGrantIdToFlowContractAndRecipientId(
   db: Context["db"],
@@ -27,3 +28,16 @@ export async function getGrantIdFromFlowContractAndRecipientId(
 
 const getId = (flowContract: string, recipientId: string) =>
   `${flowContract.toLowerCase()}-${recipientId}`
+
+export async function calculateRootContract(
+  db: Context["db"],
+  contract: string,
+  parentContract: string
+) {
+  if (parentContract === zeroAddress) return contract.toLowerCase()
+
+  const parent = await db.find(grants, { id: parentContract.toLowerCase() })
+  if (!parent) throw new Error(`Parent grant not found: ${parentContract}`)
+
+  return parent.rootContract
+}

--- a/indexer/src/grants/recipients/custom-flow/recipient-created.ts
+++ b/indexer/src/grants/recipients/custom-flow/recipient-created.ts
@@ -25,6 +25,7 @@ async function handleRecipientCreated(params: {
   const grantId = recipientId.toString()
   const timestamp = Number(event.block.timestamp)
   const flow = await getFlow(context.db, flowAddress)
+  const rootContract = flow.rootContract
 
   await context.db.update(grants, { id: flow.id }).set((row) => ({
     activeRecipientCount: row.activeRecipientCount + 1,
@@ -48,6 +49,7 @@ async function handleRecipientCreated(params: {
     flowId: flow.id,
     submitter: approvedBy.toLowerCase(),
     parentContract: flowAddress,
+    rootContract,
     baselinePool: "",
     bonusPool: "",
     managerRewardPoolFlowRatePercent: 0,

--- a/indexer/src/grants/recipients/flow-recipient-created.ts
+++ b/indexer/src/grants/recipients/flow-recipient-created.ts
@@ -19,6 +19,9 @@ async function handleFlowRecipientCreated(params: {
   const parentFlowContract = event.log.address.toLowerCase() as `0x${string}`
   const submitter = event.transaction.from.toLowerCase() as `0x${string}`
   const flowContract = recipient.toLowerCase() as `0x${string}`
+  const parentFlow = await context.db.find(grants, { id: parentFlowContract })
+  if (!parentFlow) throw new Error("Parent grant not found")
+  const rootContract = parentFlow.rootContract
 
   const grant = await context.db.find(grants, { id: recipientId })
 
@@ -34,6 +37,7 @@ async function handleFlowRecipientCreated(params: {
     activatedAt: timestamp,
     submitter,
     recipientId,
+    rootContract,
     isOnchainStartup: isOnchainStartup(parentFlowContract),
     isAccelerator: isAccelerator(flowContract),
   })

--- a/indexer/src/grants/recipients/nouns/recipient-created.ts
+++ b/indexer/src/grants/recipients/nouns/recipient-created.ts
@@ -30,10 +30,12 @@ async function handleRecipientCreated(params: {
   const timestamp = Number(event.block.timestamp)
 
   const parentFlow = await getFlow(context.db, flowAddress)
+  const rootContract = parentFlow.rootContract
 
   const grant = await context.db.update(grants, { id: recipientId.toString() }).set({
     ...metadata,
     recipient,
+    rootContract,
     updatedAt: Number(event.block.timestamp),
     activatedAt: Number(event.block.timestamp),
     isActive: true,

--- a/indexer/src/tcr/applications.ts
+++ b/indexer/src/tcr/applications.ts
@@ -27,6 +27,7 @@ async function handleItemSubmitted(params: {
       functionName: "challengePeriodDuration",
     }),
   ])
+  const rootContract = flow.rootContract
 
   const [recipient, metadata, recipientType] = decodeAbiParameters(
     [
@@ -60,6 +61,7 @@ async function handleItemSubmitted(params: {
     flowId: flow.id,
     submitter: _submitter.toLowerCase(),
     parentContract: flow.recipient,
+    rootContract,
     isTopLevel: false,
     isFlow: recipientType === RecipientType.FlowContract,
     isRemoved: false,

--- a/web/lib/database/flows.prisma
+++ b/web/lib/database/flows.prisma
@@ -138,6 +138,7 @@ view Grant {
   flowId                           String  @map("flow_id")
   submitter                        String
   parentContract                   String  @map("parent_contract")
+  rootContract                     String  @map("root_contract")
   isTopLevel                       Boolean @map("is_top_level")
   isFlow                           Boolean @map("is_flow")
   title                            String


### PR DESCRIPTION
## Summary
- add `rootContract` to grant schema and DB view
- compute root contract for flows and recipients

## Testing
- `pnpm lint` in `indexer`
- `pnpm typecheck` in `indexer`
- `pnpm codegen` in `indexer`
- `pnpm lint && pnpm typecheck` in `web`
- `pnpm db:generate` in `web`
- `pnpm build` in `web`


------
https://chatgpt.com/codex/tasks/task_e_685aeee00a248327adf88cf664390f4f