### PR TITLE
feat(web): allow managers to remove grants and flows

### DIFF
--- a/web/app/(custom-flow)/custom-flow-page.tsx
+++ b/web/app/(custom-flow)/custom-flow-page.tsx
@@ -36,6 +36,7 @@ export async function CustomFlowPage(props: Props) {
   )
 
   const isTopLevel = flow.parentContract === zeroAddress
+  const canManage = user?.address === flow.manager
 
   const relevantGrants = isTopLevel ? grants : [flow]
 
@@ -129,9 +130,18 @@ export async function CustomFlowPage(props: Props) {
               description="There are no approved projects yet"
             />
           ) : isTopLevel ? (
-            <FlowsList flows={grants.sort(sortGrants)} />
+            <FlowsList
+              flows={grants.sort(sortGrants)}
+              canManage={canManage}
+              contract={getEthAddress(flow.recipient)}
+              chainId={flow.chainId}
+            />
           ) : (
-            <GrantsList grants={grants.sort(sortGrants)} flow={flow} />
+            <GrantsList
+              grants={grants.sort(sortGrants)}
+              flow={flow}
+              canManage={canManage}
+            />
           )}
         </div>
         <AllocationBar />

--- a/web/app/components/flows-list.tsx
+++ b/web/app/components/flows-list.tsx
@@ -7,17 +7,25 @@ import { FlowCard } from "./flow-card"
 
 interface Props {
   flows: Array<LimitedFlow>
+  canManage?: boolean
+  contract: `0x${string}`
+  chainId: number
 }
 
 export default function FlowsList(props: Props) {
-  const { flows } = props
+  const { flows, canManage = false, contract, chainId } = props
   const { isActive } = useAllocate()
 
   if (isActive) {
     return (
       <Card>
         <CardContent>
-          <FlowsTable flows={flows} />
+          <FlowsTable
+            flows={flows}
+            canManage={canManage}
+            contract={contract}
+            chainId={chainId}
+          />
         </CardContent>
       </Card>
     )

--- a/web/app/components/flows-table.tsx
+++ b/web/app/components/flows-table.tsx
@@ -15,6 +15,7 @@ import type { Grant } from "@prisma/flows"
 import Image from "next/image"
 import Link from "next/link"
 import { AllocationInput } from "@/components/global/allocation-input"
+import { RemoveRecipientButton } from "@/components/global/remove-recipient-button"
 import { MonthlyBudget, type FlowWithBudget } from "./monthly-budget"
 
 export type LimitedFlow = FlowWithBudget &
@@ -36,10 +37,13 @@ export type LimitedFlow = FlowWithBudget &
 
 interface Props {
   flows: Array<LimitedFlow>
+  canManage?: boolean
+  contract: `0x${string}`
+  chainId: number
 }
 
 export const FlowsTable = (props: Props) => {
-  const { flows } = props
+  const { flows, canManage = false, contract, chainId } = props
 
   return (
     <Table>
@@ -50,7 +54,9 @@ export const FlowsTable = (props: Props) => {
           <TableHead className="text-center">Paid out</TableHead>
           <TableHead className="text-center">Monthly support</TableHead>
           <TableHead className="text-center">Votes</TableHead>
-          <TableHead className="text-center">Your Vote</TableHead>
+          <TableHead className="text-center">
+            {canManage ? "Manage" : "Your Vote"}
+          </TableHead>
         </TableRow>
       </TableHeader>
       <TableBody>
@@ -109,8 +115,17 @@ export const FlowsTable = (props: Props) => {
               </TableCell>
               <TableCell className="text-center">{flow.allocationsCount}</TableCell>
               <TableCell className="w-[100px] max-w-[100px] text-center">
-                <div className="px-0.5">
-                  <AllocationInput recipientId={flow.recipientId} />
+                <div className="flex items-center gap-1 px-0.5">
+                  <div className="w-[100px]">
+                    <AllocationInput recipientId={flow.recipientId} />
+                  </div>
+                  {canManage && (
+                    <RemoveRecipientButton
+                      contract={contract}
+                      recipientId={flow.recipientId}
+                      chainId={chainId}
+                    />
+                  )}
                 </div>
               </TableCell>
             </TableRow>

--- a/web/app/draft/[draftId]/self-managed-draft-publish-button.tsx
+++ b/web/app/draft/[draftId]/self-managed-draft-publish-button.tsx
@@ -67,38 +67,36 @@ export function ManagedFlowDraftPublishButton(props: Props) {
           {draft.opportunityId ? "Approve application" : "Add to flow"}
         </AuthButton>
       </DialogTrigger>
-      <DialogContent className="sm:max-w-screen-xs">
+      <DialogContent className="sm:max-w-md">
         <DialogHeader>
-          <DialogTitle className="px-4 text-center text-xl font-medium">
-            Add {draft.title} to {flow.title}
-          </DialogTitle>
+          <DialogTitle>Add to the {flow.title} flow</DialogTitle>
         </DialogHeader>
-        <div>
+        <div className="space-y-4">
           <p className="text-sm text-muted-foreground">
             This is a self managed flow. You can add and remove applicants at any time, and set a
             custom flow rate for each applicant.
           </p>
-        </div>
-        <div className="flex justify-end space-x-2">
-          {flow.isAccelerator ? (
-            <AddFlowToFlowButton
-              draft={draft}
-              contract={flow.recipient as `0x${string}`}
-              chainId={flow.chainId}
-              onSuccess={() => {
-                ref.current?.click() // close dialog
-              }}
-            />
-          ) : (
-            <AddRecipientToFlowButton
-              draft={draft}
-              contract={flow.recipient as `0x${string}`}
-              chainId={flow.chainId}
-              onSuccess={() => {
-                ref.current?.click() // close dialog
-              }}
-            />
-          )}
+          <div className="flex justify-end">
+            {flow.isAccelerator ? (
+              <AddFlowToFlowButton
+                draft={draft}
+                contract={flow.recipient as `0x${string}`}
+                chainId={flow.chainId}
+                onSuccess={() => {
+                  ref.current?.click() // close dialog
+                }}
+              />
+            ) : (
+              <AddRecipientToFlowButton
+                draft={draft}
+                contract={flow.recipient as `0x${string}`}
+                chainId={flow.chainId}
+                onSuccess={() => {
+                  ref.current?.click() // close dialog
+                }}
+              />
+            )}
+          </div>
         </div>
       </DialogContent>
     </Dialog>

--- a/web/app/flow/[flowId]/page.tsx
+++ b/web/app/flow/[flowId]/page.tsx
@@ -36,6 +36,7 @@ export default async function FlowPage(props: Props) {
   )
 
   const monthlyImpact = flow.derivedData?.impactMonthly
+  const isManager = flow.manager === user?.address
 
   return (
     <AgentChatProvider
@@ -61,7 +62,11 @@ export default async function FlowPage(props: Props) {
         {!subgrants || subgrants.length === 0 ? (
           <EmptyState title="No grants found" description="There are no approved grants yet" />
         ) : (
-          <GrantsList flow={flow} grants={grants.sort(sortGrants)} />
+          <GrantsList
+            flow={flow}
+            grants={grants.sort(sortGrants)}
+            canManage={isManager}
+          />
         )}
       </div>
 

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -27,6 +27,8 @@ export default async function Home() {
     getUser(),
   ])
 
+  const canManage = user?.address === pool.manager
+
   return (
     <AllocationProvider
       chainId={pool.chainId}
@@ -53,7 +55,12 @@ export default async function Home() {
         </div>
 
         <div className="container my-6">
-          <FlowsList flows={activeFlows} />
+          <FlowsList
+            flows={activeFlows}
+            canManage={canManage}
+            contract={getEthAddress(pool.recipient)}
+            chainId={pool.chainId}
+          />
         </div>
         <div className="pt-12">
           <Footer />

--- a/web/components/global/grants-list.tsx
+++ b/web/components/global/grants-list.tsx
@@ -19,17 +19,18 @@ interface Props {
       profile: Profile
     }
   >
+  canManage?: boolean
 }
 
 export default function GrantsList(props: Props) {
-  const { flow, grants } = props
+  const { flow, grants, canManage = false } = props
   const { isActive } = useAllocate()
 
   if (isActive) {
     return (
       <Card>
         <CardContent>
-          <GrantsTable flow={flow} grants={grants} />
+          <GrantsTable canManage={canManage} flow={flow} grants={grants} />
         </CardContent>
       </Card>
     )


### PR DESCRIPTION
## Summary
- expose `canManage` in `GrantsList`
- pass manager info and parent contract into `FlowsList`
- support remove button in `FlowsTable`
- wire manager checks in flow and pool pages

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_685c1eb1b47083278074add0df009e2b