### PR TITLE
feat: track owner on grants

### DIFF
--- a/indexer/ponder.schema.ts
+++ b/indexer/ponder.schema.ts
@@ -46,6 +46,7 @@ export const grants = onchainTable(
     challengedRecipientCount: t.integer().notNull(),
     bonusPool: t.text().notNull(),
     manager: t.text().notNull(),
+    owner: t.text().notNull(),
     managerRewardPool: t.text().notNull(),
     managerRewardSuperfluidPool: t.text().notNull(),
     superToken: t.text().notNull(),

--- a/indexer/src/flows/ownership-transferred.ts
+++ b/indexer/src/flows/ownership-transferred.ts
@@ -1,0 +1,25 @@
+import { ponder, type Context, type Event } from "ponder:registry"
+import { grants } from "ponder:schema"
+
+ponder.on("CustomFlow:OwnershipTransferred", handleOwnershipTransferred)
+ponder.on("NounsFlow:OwnershipTransferred", handleOwnershipTransferred)
+ponder.on("NounsFlowChildren:OwnershipTransferred", handleOwnershipTransferred)
+
+async function handleOwnershipTransferred(params: {
+  event: Event<"CustomFlow:OwnershipTransferred">
+  context: Context<"CustomFlow:OwnershipTransferred">
+}) {
+  const { event, context } = params
+  const { newOwner } = event.args
+
+  const grantId = event.log.address.toLowerCase()
+  const grant = await context.db.find(grants, { id: grantId })
+  if (!grant) {
+    return
+  }
+
+  await context.db.update(grants, { id: grantId }).set({
+    owner: newOwner.toLowerCase(),
+  })
+}
+

--- a/indexer/src/grants/flow-initialized/custom-flow-initialized.ts
+++ b/indexer/src/grants/flow-initialized/custom-flow-initialized.ts
@@ -12,6 +12,7 @@ import { getFlowMetadataAndRewardPool } from "./initialized-helpers"
 import { accelerators, customFlows } from "../../../addresses"
 import { isAccelerator } from "../recipients/helpers"
 import { fetchTokenInfo } from "../../utils/token-utils"
+import { customFlowImplAbi } from "../../../abis"
 
 ponder.on("CustomFlow:FlowInitialized", handleFlowInitialized)
 
@@ -41,6 +42,12 @@ async function handleFlowInitialized(params: {
   const { metadata, managerRewardSuperfluidPool, underlyingERC20Token } =
     await getFlowMetadataAndRewardPool(context, contract, managerRewardPool, superToken)
 
+  const owner = await context.client.readContract({
+    address: contract,
+    abi: customFlowImplAbi,
+    functionName: "owner",
+  })
+
   const {
     symbol: underlyingTokenSymbol,
     prefix: underlyingTokenPrefix,
@@ -69,6 +76,7 @@ async function handleFlowInitialized(params: {
     isRemoved: false,
     parentContract,
     rootContract,
+    owner,
     managerRewardPool: managerRewardPool.toLowerCase(),
     managerRewardSuperfluidPool: managerRewardSuperfluidPool.toLowerCase(),
     superToken: superToken.toLowerCase(),

--- a/indexer/src/grants/flow-initialized/nouns-child-flow-initialized.ts
+++ b/indexer/src/grants/flow-initialized/nouns-child-flow-initialized.ts
@@ -11,6 +11,7 @@ import { isAccelerator } from "../recipients/helpers"
 import { getFlowMetadataAndRewardPool } from "./initialized-helpers"
 import { calculateRootContract } from "../grant-helpers"
 import { fetchTokenInfo } from "../../utils/token-utils"
+import { customFlowImplAbi } from "../../../abis"
 
 ponder.on("NounsFlowChildren:FlowInitialized", handleFlowInitialized)
 
@@ -37,6 +38,12 @@ async function handleFlowInitialized(params: {
   const { metadata, managerRewardSuperfluidPool, underlyingERC20Token } =
     await getFlowMetadataAndRewardPool(context, contract, managerRewardPool, superToken)
 
+  const owner = await context.client.readContract({
+    address: contract,
+    abi: customFlowImplAbi,
+    functionName: "owner",
+  })
+
   const {
     symbol: underlyingTokenSymbol,
     prefix: underlyingTokenPrefix,
@@ -62,6 +69,7 @@ async function handleFlowInitialized(params: {
     isRemoved: false,
     parentContract,
     rootContract,
+    owner,
     managerRewardPool: managerRewardPool.toLowerCase(),
     managerRewardSuperfluidPool: managerRewardSuperfluidPool.toLowerCase(),
     superToken: superToken.toLowerCase(),

--- a/indexer/src/grants/flow-initialized/nouns-flow-initialized.ts
+++ b/indexer/src/grants/flow-initialized/nouns-flow-initialized.ts
@@ -16,6 +16,7 @@ import { getFlowMetadataAndRewardPool } from "./initialized-helpers"
 import { isAccelerator } from "../recipients/helpers"
 import { calculateRootContract } from "../grant-helpers"
 import { fetchTokenInfo } from "../../utils/token-utils"
+import { customFlowImplAbi } from "../../../abis"
 
 ponder.on("NounsFlow:FlowInitialized", handleFlowInitialized)
 
@@ -42,6 +43,12 @@ async function handleFlowInitialized(params: {
   const { metadata, managerRewardSuperfluidPool, underlyingERC20Token } =
     await getFlowMetadataAndRewardPool(context, contract, managerRewardPool, superToken)
 
+  const owner = await context.client.readContract({
+    address: contract,
+    abi: customFlowImplAbi,
+    functionName: "owner",
+  })
+
   const {
     symbol: underlyingTokenSymbol,
     prefix: underlyingTokenPrefix,
@@ -67,6 +74,7 @@ async function handleFlowInitialized(params: {
     isRemoved: false,
     parentContract,
     rootContract,
+    owner,
     managerRewardPool: managerRewardPool.toLowerCase(),
     managerRewardSuperfluidPool: managerRewardSuperfluidPool.toLowerCase(),
     superToken: superToken.toLowerCase(),

--- a/indexer/src/grants/recipients/custom-flow/recipient-created.ts
+++ b/indexer/src/grants/recipients/custom-flow/recipient-created.ts
@@ -50,6 +50,7 @@ async function handleRecipientCreated(params: {
     submitter: approvedBy.toLowerCase(),
     parentContract: flowAddress,
     rootContract,
+    owner: "",
     baselinePool: "",
     bonusPool: "",
     managerRewardPoolFlowRatePercent: 0,

--- a/indexer/src/tcr/applications.ts
+++ b/indexer/src/tcr/applications.ts
@@ -62,6 +62,7 @@ async function handleItemSubmitted(params: {
     submitter: _submitter.toLowerCase(),
     parentContract: flow.recipient,
     rootContract,
+    owner: "",
     isTopLevel: false,
     isFlow: recipientType === RecipientType.FlowContract,
     isRemoved: false,


### PR DESCRIPTION
## Summary
- add `owner` column to `grants` schema
- capture contract owner for flows on initialization
- record owner updates on `OwnershipTransferred` events
- set owner to empty string for non-flow grants

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm codegen`

------
https://chatgpt.com/codex/tasks/task_e_685ee341a3ac8327b03f8d74628b5915