### PR TITLE
feat(web): allow deleting active flows

### DIFF
--- a/web/components/fund-flow/fund-flow.tsx
+++ b/web/components/fund-flow/fund-flow.tsx
@@ -122,6 +122,7 @@ export function FundFlow(props: Props & ComponentProps<typeof Button>) {
           address={address as `0x${string}`}
           receiver={flow.recipient}
           superToken={superToken as `0x${string}`}
+          underlyingToken={underlyingERC20Token as `0x${string}`}
         />
 
         <div className="mt-6 space-y-6">

--- a/web/components/fund-flow/rebalance-flow-button.tsx
+++ b/web/components/fund-flow/rebalance-flow-button.tsx
@@ -18,6 +18,7 @@ interface RebalanceFlowButtonProps {
   address: string
   receiver: string
   superToken: `0x${string}`
+  underlyingToken: `0x${string}`
   className?: string
 }
 
@@ -27,6 +28,7 @@ export function RebalanceFlowButton({
   address,
   receiver,
   superToken,
+  underlyingToken,
   className,
 }: RebalanceFlowButtonProps) {
   const router = useRouter()
@@ -56,6 +58,7 @@ export function RebalanceFlowButton({
     contract,
     chainId,
     superToken,
+    underlyingToken,
     userAddress: address as `0x${string}`,
     onSuccess,
   })

--- a/web/components/fund-flow/superfluid-flows-list.tsx
+++ b/web/components/fund-flow/superfluid-flows-list.tsx
@@ -30,7 +30,7 @@ export function SuperfluidFlowsList({
   showTitle = true,
   tokens = TOKENS,
 }: SuperfluidFlowsListProps) {
-  const { data: flows, isLoading, error } = useExistingFlows(address, chainId)
+  const { data: flows, error, mutate } = useExistingFlows(address, chainId)
 
   if (!address) return null
 
@@ -76,6 +76,8 @@ export function SuperfluidFlowsList({
             key={`${flow.token}-${flow.sender}-${flow.receiver}-${index}`}
             flow={flow}
             tokens={tokens}
+            address={address}
+            mutate={mutate}
           />
         ))}
       </div>
@@ -86,11 +88,11 @@ export function SuperfluidFlowsList({
 interface SuperfluidFlowItemProps {
   flow: SuperfluidFlowWithState
   tokens: Record<string, TokenInfo>
+  address: string
+  mutate: () => void
 }
 
-function SuperfluidFlowItem({ flow, tokens }: SuperfluidFlowItemProps) {
-  const { address } = useLogin()
-  const { mutate } = useExistingFlows(address, flow.chainId)
+function SuperfluidFlowItem({ flow, tokens, address, mutate }: SuperfluidFlowItemProps) {
   const { deleteFlow, isLoading: isDeleting } = useDeleteFlow({
     chainId: flow.chainId,
     superTokenAddress: flow.token as `0x${string}`,
@@ -135,23 +137,25 @@ function SuperfluidFlowItem({ flow, tokens }: SuperfluidFlowItemProps) {
             </div>
           </div>
 
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-1">
             <Badge variant={flow.isActive ? "default" : "secondary"} className="text-[10px]">
               {flow.isActive ? "Active" : "Closed"}
             </Badge>
+            {flow.isActive && (
+              <div className="grid grid-cols-[0fr] transition-all duration-200 group-hover:grid-cols-[1fr]">
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  className="h-6 w-6 overflow-hidden opacity-0 transition-all duration-200 group-hover:opacity-100"
+                  onClick={deleteFlow}
+                  disabled={isDeleting}
+                >
+                  <XIcon className="h-3 w-3" />
+                </Button>
+              </div>
+            )}
           </div>
         </div>
-        {flow.isActive && (
-          <Button
-            size="icon"
-            variant="ghost"
-            className="absolute right-2 top-2 opacity-0 transition-opacity group-hover:opacity-100"
-            onClick={deleteFlow}
-            disabled={isDeleting}
-          >
-            <XIcon className="h-4 w-4" />
-          </Button>
-        )}
       </CardContent>
     </Card>
   )

--- a/web/components/ui/hooks/auth-click.ts
+++ b/web/components/ui/hooks/auth-click.ts
@@ -19,6 +19,9 @@ export function useAuthClick(onConnect?: OnConnectCallback) {
         connectWallet()
       }
       onConnect?.()
+    } else if (!authenticated) {
+      e.preventDefault()
+      login()
     }
 
     return e

--- a/web/lib/erc20/super-token/index.ts
+++ b/web/lib/erc20/super-token/index.ts
@@ -1,6 +1,7 @@
 // Flow operation hooks
 export { useCreateFlow } from "./use-create-flow"
 export { useUpdateFlow } from "./use-update-flow"
+export { useDeleteFlow } from "./use-delete-flow"
 
 // Flow operation helpers
 export {

--- a/web/lib/erc20/super-token/use-delete-flow.ts
+++ b/web/lib/erc20/super-token/use-delete-flow.ts
@@ -1,0 +1,44 @@
+"use client"
+
+import { cfav1Abi } from "@/lib/abis"
+import { useContractTransaction } from "@/lib/wagmi/use-contract-transaction"
+import { getCfaAddress } from "./addresses"
+
+interface UseDeleteFlowProps {
+  chainId: number
+  superTokenAddress: `0x${string}`
+  sender: `0x${string}` | undefined
+  receiver: `0x${string}`
+  onSuccess?: (hash: string) => void
+}
+
+export function useDeleteFlow({
+  chainId,
+  superTokenAddress,
+  sender,
+  receiver,
+  onSuccess,
+}: UseDeleteFlowProps) {
+  const { prepareWallet, writeContract, isLoading, ...rest } = useContractTransaction({
+    chainId,
+    loading: "Deleting flow...",
+    success: "Flow deleted successfully",
+    onSuccess,
+  })
+
+  const deleteFlow = async () => {
+    await prepareWallet()
+    if (!sender) return
+
+    writeContract({
+      account: sender,
+      address: getCfaAddress(chainId),
+      abi: cfav1Abi,
+      functionName: "deleteFlow",
+      args: [superTokenAddress, sender, receiver, "0x"],
+      chainId,
+    })
+  }
+
+  return { deleteFlow, isLoading, ...rest }
+}


### PR DESCRIPTION
## Summary
- allow deleting active Superfluid flows in the funding modal
- export `useDeleteFlow` hook
- show delete button on hover for active flows

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6862d3f63fa4832788ed537282cdc806