### PR TITLE
feat(web): add metadata for apply flow page

### DIFF
--- a/web/app/apply/[flowId]/page.tsx
+++ b/web/app/apply/[flowId]/page.tsx
@@ -2,10 +2,24 @@ import { AgentChatProvider } from "@/app/chat/components/agent-chat"
 import { getPrivyIdToken } from "@/lib/auth/get-user-from-cookie"
 import { getUser } from "@/lib/auth/user"
 import { getFlow } from "@/lib/database/queries/flow"
+import { getIpfsUrl } from "@/lib/utils"
+import type { Metadata } from "next"
 import { ApplicationChat } from "./components/application-chat"
 
 interface Props {
   params: Promise<{ flowId: string }>
+}
+
+export async function generateMetadata(props: Props): Promise<Metadata> {
+  const { flowId } = await props.params
+
+  const flow = await getFlow(flowId)
+
+  return {
+    title: `Apply for ${flow.title}`,
+    description: flow.tagline ?? flow.description,
+    openGraph: { images: [getIpfsUrl(flow.image, "pinata")] },
+  }
 }
 
 export default async function ApplyPage(props: Props) {


### PR DESCRIPTION
## Summary
- add `generateMetadata` with Open Graph image for the apply flow page

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_686602df9bdc832794ac7e3d6c3b918a