### PR TITLE
feat(web): dynamic startup redirects

### DIFF
--- a/web/app/(custom-flow)/[customFlowId]/page.tsx
+++ b/web/app/(custom-flow)/[customFlowId]/page.tsx
@@ -2,9 +2,10 @@ import "server-only"
 
 import { getFlow } from "@/lib/database/queries/flow"
 import { Metadata } from "next"
-import { notFound } from "next/navigation"
+import { notFound, redirect } from "next/navigation"
 import { CustomFlowPage as CustomFlowPageComponent } from "../custom-flow-page"
 import { CustomFlowId, getCustomFlow } from "../custom-flows"
+import { getStartupIdFromSlug } from "@/lib/onchain-startup/startup"
 
 interface Props {
   params: Promise<{ customFlowId: string }>
@@ -12,6 +13,13 @@ interface Props {
 
 export async function generateMetadata(props: Props): Promise<Metadata> {
   const { customFlowId } = await props.params
+  try {
+    const startupId = getStartupIdFromSlug(customFlowId)
+    redirect(`/startup/${startupId}`)
+    return {}
+  } catch {
+    // not a startup slug; continue
+  }
   const customFlow = getCustomFlow(customFlowId as CustomFlowId)
 
   if (!customFlow) notFound()
@@ -21,6 +29,12 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
 
 export default async function CustomFlowPage(props: Props) {
   const { customFlowId } = await props.params
+  try {
+    const startupId = getStartupIdFromSlug(customFlowId)
+    redirect(`/startup/${startupId}`)
+  } catch {
+    // continue to custom flow
+  }
   const customFlow = getCustomFlow(customFlowId as CustomFlowId)
 
   if (!customFlow) notFound()

--- a/web/app/legal/privacy/page.tsx
+++ b/web/app/legal/privacy/page.tsx
@@ -1,0 +1,27 @@
+import { Markdown } from "@/components/ui/markdown"
+import { Metadata } from "next"
+import { PRIVACY_CONTENT } from "./privacy-content"
+
+export const metadata: Metadata = {
+  title: "Privacy Policy",
+  description: "Privacy Policy for Flows.wtf platform",
+}
+
+export default function PrivacyPolicyPage() {
+  const lastModified = "July 11, 2025"
+
+  return (
+    <main>
+      <div className="container my-20 max-w-4xl">
+        <div className="space-y-8">
+          <div className="space-y-4">
+            <h1 className="text-3xl font-medium tracking-tight">Privacy Policy</h1>
+            <p className="text-sm text-muted-foreground">Last modified: {lastModified}</p>
+          </div>
+
+          <Markdown>{PRIVACY_CONTENT}</Markdown>
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/web/app/legal/privacy/privacy-content.ts
+++ b/web/app/legal/privacy/privacy-content.ts
@@ -3,7 +3,7 @@ export const PRIVACY_CONTENT = `
 
 **Effective Date:** July 11, 2025  
 **Snapshot:** "Privacy-first approach for non-custodial streaming funding."  
-**Commit Hash:** 0000000000000000000000000000000000000000 
+**Commit Hash:** 6a8ca5daa71f96bab4e25897349c44346eaf6270 
 
 This Privacy Policy (the “Policy”) explains how Just Cobuild, Co., a Delaware C-Corporation (“Cobuild”, the “Company”, “we”, “us”, or “our”) collects, uses, and shares data in connection with the flows.wtf platform, including the Interface, smart contracts, and related services (collectively, the “Services”). Your use of the Services is subject to this Policy as well as our [Terms of Service](/terms).
 

--- a/web/app/legal/privacy/privacy-content.ts
+++ b/web/app/legal/privacy/privacy-content.ts
@@ -1,0 +1,91 @@
+export const PRIVACY_CONTENT = `
+# Just Cobuild, Co. Privacy Policy
+
+**Effective Date:** July 11, 2025  
+**Snapshot:** "Privacy-first approach for non-custodial streaming funding."  
+**Commit Hash:** 0000000000000000000000000000000000000000 
+
+This Privacy Policy (the “Policy”) explains how Just Cobuild, Co., a Delaware C-Corporation (“Cobuild”, the “Company”, “we”, “us”, or “our”) collects, uses, and shares data in connection with the flows.wtf platform, including the Interface, smart contracts, and related services (collectively, the “Services”). Your use of the Services is subject to this Policy as well as our [Terms of Service](/terms).
+
+#### High-Level Summary
+
+- Cobuild is a US-based company operating flows.wtf, a non-custodial platform for continuous funding via streaming smart contracts. We comply with applicable US laws, GDPR, and CCPA.
+- The Flow protocol is permissionless and not governed by Cobuild.
+- We do not collect or store personal data such as first name, last name, street address, date of birth, email address, or IP address in connection with your use of the Services, unless voluntarily provided.
+- We collect limited non-identifiable data, such as public on-chain data (e.g., wallet addresses), and minimal off-chain data (e.g., device type, browser version) for analytics, security, and improvements—not to track individuals.
+- If you opt-in for emails (e.g., newsletters or updates), we store your email to send them; you can unsubscribe anytime. We do not link emails to wallet addresses or other data.
+- We explore privacy enhancements like opt-out prompts and privacy-focused tools.
+- Users can employ client-side privacy methods (e.g., VPNs, new wallets).
+- Material changes to this Policy will be posted here with advance notice.
+
+#### Data We Collect
+
+Privacy is fundamental to our mission. We value transparency and collect only what's necessary. We do not require user accounts and avoid storing personal data. As noted in our Terms (Section 9), we currently do not use tracking cookies or similar technologies (if that changes, we'll update this Policy beforehand). **We honor "Do Not Track" (DNT) signals from browsers where feasible.** When you interact with the Services, we collect:
+
+- **Publicly-available blockchain data.** When you connect your non-custodial wallet, we collect your public wallet address and on-chain activity (e.g., transactions, Farcaster activity) to enable features like streaming, voting, and compliance screening (e.g., for sanctions via OFAC checks). We may use third-party analytics providers. Wallet addresses are public and not personally identifying alone.
+- **Information from localStorage and other tracking technologies.** We and our providers may collect data from localStorage, cookies (if implemented), or similar to personalize the Services (e.g., remembering imported tokens or preferences). This includes browser type, device language, operating system, and aggregated usage patterns. We analyze these collectively to improve UX.
+- **Information from other sources.** We may receive wallet or transaction data from service providers for legal compliance (e.g., preventing illicit activity) or during grant-round escrow (limited custody exception per Terms Section 4.2).
+- **Survey or usability information.** If you join a survey or study, we record provided biographical info (e.g., name, email, job title), responses, and interactions.
+- **Correspondence.** We receive info you provide via email (e.g., legal@justco.build), support channels, social media (e.g., X/Twitter), or surveys.
+- **Biographical information.** For job applications, we collect details like name, email, resume, and work status.
+- **Minimal telemetry.** As per our Terms, we collect anonymized data on Service usage for analytics and improvements, based on legitimate interests.
+- **Third-party integrations.** The Services integrate with third parties (e.g., Juicebox, Farcaster, wallet providers). We do not control their data practices; review their privacy policies.
+
+#### How We Use Your Data
+
+We use data solely for:
+
+- Providing and improving the Services (e.g., funding streams, interface personalization).
+- Analytics and security (e.g., detecting exploits, aggregated insights for product vision).
+- Legal compliance (e.g., sanctions screening, tax reporting if required).
+- Communicating with you (e.g., support responses, opt-in emails).
+- Marketing (only with consent; e.g., newsletters).
+- Processing job applications or surveys.
+
+Processing is based on: your consent (e.g., emails), contract performance (e.g., Service access), legitimate interests (e.g., security, improvements), or legal obligations.
+
+#### Sharing Your Data
+
+We do not sell data **or share it for cross-context behavioral advertising**. Sharing is limited to:
+
+- **Service providers and affiliates:** Third parties (e.g., analytics tools, hosting) bound by confidentiality and data protection agreements.
+- **Legal requirements:** To comply with laws, subpoenas, or authorities (e.g., OFAC).
+- **Business transfers:** In mergers, acquisitions, or asset sales.
+- **With your consent:** E.g., sharing on-chain data with indexers.
+
+For GDPR: Processors are vetted; international transfers (e.g., to US) use standard contractual clauses or adequacy decisions.
+
+#### Data Security
+
+We use industry-standard measures like encryption, access controls, and secure protocols. Report vulnerabilities to security@justco.build (per Terms Section 10; discretionary rewards for good-faith disclosures). We are not liable for blockchain risks or third-party breaches (e.g., wallet providers like Juicebox, Farcaster). **We cannot guarantee absolute security due to inherent internet and blockchain risks.**
+
+#### Your Choices and Rights
+
+- **Opt-outs:** Unsubscribe from emails anytime; manage localStorage/cookies via browser settings.
+- **Access and control:** Request access, correction, deletion, or portability of your data.
+- **GDPR rights (if applicable):** Object to processing, withdraw consent, restrict use; lodge complaints with supervisory authorities. **We aim to respond within one month, extendable to two if complex.**
+- **CCPA rights (California residents):** Know collected data, delete it, opt-out of sales (we don't sell). Non-discrimination for exercising rights. Submit requests via legal@justco.build; we'll verify and respond within 45 days.
+- We do not use data for automated decision-making with legal effects. **Note: On-chain data (e.g., transactions) is public and immutable; we cannot edit or delete it.**
+
+#### Data Retention
+
+We retain data only as needed: e.g., technical logs for 6-12 months, correspondence until resolved, on-chain data as public. Deletion upon request or when no longer necessary, subject to legal holds.
+
+#### International Data Transfers
+
+Data may be processed in the US or other countries. We ensure safeguards like GDPR-compliant clauses for transfers outside EEA/Switzerland.
+
+#### Children's Privacy
+
+Services are for users 18+ (per Terms Section 2.1); we do not knowingly collect data from children under 13 **(or higher where required by law, e.g., 16 under GDPR)**.
+
+#### Changes to This Policy
+
+We may update this Policy; changes posted on flows.wtf with 30-day notice for material updates (per Terms Section 16). Continued use constitutes acceptance.
+
+#### Contact Us
+
+For questions or rights exercises: legal@justco.build or Just Cobuild, Co., 131 Continental Dr Suite 305, Newark DE 19713 USA.
+
+This Policy aligns with our Terms; in conflicts, Terms prevail.
+`

--- a/web/app/legal/terms/page.tsx
+++ b/web/app/legal/terms/page.tsx
@@ -1,0 +1,27 @@
+import { Markdown } from "@/components/ui/markdown"
+import { Metadata } from "next"
+import { TERMS_CONTENT } from "./terms-content"
+
+export const metadata: Metadata = {
+  title: "Terms of Service",
+  description: "Terms of Service for Flows.wtf platform",
+}
+
+export default function TermsOfServicePage() {
+  const lastModified = "July 11, 2025"
+
+  return (
+    <main>
+      <div className="container my-20 max-w-4xl">
+        <div className="space-y-8">
+          <div className="space-y-4">
+            <h1 className="text-3xl font-medium tracking-tight">Terms of Service</h1>
+            <p className="text-sm text-muted-foreground">Last modified: {lastModified}</p>
+          </div>
+
+          <Markdown>{TERMS_CONTENT}</Markdown>
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/web/app/legal/terms/terms-content.ts
+++ b/web/app/legal/terms/terms-content.ts
@@ -1,0 +1,325 @@
+export const TERMS_CONTENT = `
+## Just Cobuild, Co. Terms of Service
+
+**Effective Date:** July 11, 2025  
+**Snapshot:** "Continuous funding for grassroots projects via streaming smart-contracts."  
+**Commit Hash:** 0000000000000000000000000000000000000000
+
+### IMPORTANT NOTICE
+
+This Agreement includes a class-action waiver, jury-trial waiver, and a statement of blockchain-related risks. By accepting these terms, you waive your rights to participate in class actions and jury trials. This Agreement contains a binding arbitration clause (§15). By accepting you waive the right to a court trial except for small-claims or injunctive relief.
+
+---
+
+## 1. Introduction & Acceptance
+
+### 1.1 Contracting Entity
+
+Just Cobuild, Co., a Delaware C-Corporation ("Cobuild").
+
+### 1.2 How You Accept
+
+You accept this Agreement via wallet-connect signature, checking an acceptance box, or by continued use of our Services. If you continue to access the Services after the Effective Date, you are deemed to have accepted these Terms.
+
+### 1.3 Right to Amend
+
+Cobuild may unilaterally update these Terms with 30-day advance notice for material changes. Immaterial updates may be made immediately.
+
+### 1.4 Contact Information
+
+* Formal notices: [legal@justco.build](mailto:legal@justco.build)
+* Security bugs: [security@justco.build](mailto:security@justco.build)
+
+---
+
+## 2. Eligibility & User Restrictions
+
+### 2.1 Age Requirement
+
+You must be at least 18 years old and legally able to contract. If the laws of your jurisdiction require you to be 18 or older to enter binding contracts, you must comply with that age.
+
+### 2.2 Sanctions & Blocked Jurisdictions
+
+You represent that you are not (a) the subject of economic or trade sanctions administered or enforced by any governmental authority, nor (b) located in, organized under the laws of, or ordinarily resident in a country or territory that is the subject of country-wide or territory-wide economic sanctions. You may not use Cobuild if located in jurisdictions subject to comprehensive sanctions or identified on the OFAC SDN list.
+
+### 2.3 No Prohibited Persons
+
+You represent you are not violating any sanctions or legal prohibitions by using Cobuild.
+
+### 2.4 Export-Control Compliance
+
+You agree to comply with U.S. export controls and trade sanctions. You may not export or re-export any Cobuild software except in compliance with U.S. Export Administration Regulations and similar regimes.
+
+---
+## 3. Defined Terms
+
+The following terms have the meanings set forth below (listed alphabetically):  
+- Baseline Pool – The distribution pool in the protocol that ensures all approved recipients (Builders) receive an even split of funds, providing a foundational level of continuous support to all contributors regardless of votes.  
+- Bonus Pool – The distribution pool in the protocol where additional funds are allocated based on community votes (e.g., from Nouns DAO token holders), allowing for weighted rewards to high-impact projects beyond the baseline allocation.  
+- Builder – An individual or entity that applies to receive streamed funding for grassroots projects; Builders must maintain Farcaster activity, comply with flow rules, and meet milestones to remain eligible.  
+- Flow – The smart-contract protocol that enables continuous streaming of funds into baseline and bonus pools, governed by Nouns holders via L2 proofs, serving as an unstoppable growth engine for onchain projects.  
+- Grant-Round Escrow – The temporary holding of funds by Cobuild during designated grant rounds for operators, subject to AML/KYC checks and OFAC screening; this is the limited exception to the non-custodial nature of the Services.  
+- Interface – The frontend web application (flows.wtf) that provides a user interface for routing signed transactions to the underlying smart contracts, without custody of user assets.  
+- Juicebox Sale – The process by which Tokens are minted and sold exclusively through integrated Juicebox or Revnet contracts; Cobuild does not directly sell Tokens.  
+- Services – The Flows.wtf platform as a whole, including the Interface, smart contracts, and related tools for continuous funding, token sales via Juicebox, and community governance.  
+- Smart Contract – Permissionless, on-chain contracts (e.g., Flow.sol, FlowTCR.sol, NounsFlow.sol) deployed on EVM-compatible networks like Base L2, which autonomously manage fund streaming, voting, and recipient curation.  
+- Sponsor – A user who pays non-refundable application bonds to fund grant rounds or support projects, enabling Builders to join flows; Sponsors must abstain from illicit funding and comply with sanctions.  
+- Stream – The mechanism for second-by-second accrual and distribution of funds to approved recipients using block.timestamp, claimable at any time via compatible EVM wallets, with unclaimed amounts persisting indefinitely.  
+- Tokens – Digital assets (e.g., ERC20) minted and sold through Juicebox contracts for protocol use, such as bonding curves or fees; Tokens are not sold directly by Cobuild and carry no investment guarantees.  
+- User – Any individual or entity accessing or interacting with the Services, including but not limited to Builders, Sponsors, and voters (e.g., Nouns holders).  
+- Variable Fee – Administrative fees charged by Cobuild on streamed funds or escrowed grant programs, typically 2% deducted automatically, with rates disclosed in the Interface or per program.
+
+---
+
+## 4. Description of Services
+
+### 4.1 Non-Custodial Interface
+
+Cobuild never holds private keys or user funds.
+
+### 4.2 Limited Custody Exception
+
+Temporary escrow may occur during grant-round operations. Funds in escrow during grant-round operations are held for the duration of the grant round, typically up to 30 days, under the control of specified smart contracts as disclosed in the Interface.
+
+### 4.3 Open-Source Code
+
+Protocol and front-end code licensed under GPL-3.0.
+
+### 4.4 Smart-Contract Persistence
+
+Smart contracts remain active independently of Cobuild's web interface.
+
+### 4.5 Upgrades & Forks
+
+Protocol changes are community-driven with notices provided for material changes. Contract addresses may change as a result of upgrades, and users must verify addresses themselves.
+
+---
+
+## 5. Funding & Streaming Mechanics
+
+### 5.1 Continuous Accrual
+
+Funds accrue second-by-second using \`block.timestamp\`.
+
+### 5.2 Claiming Streams
+
+Streams can be claimed by any compatible EVM wallet; unclaimed funds persist indefinitely.
+
+### 5.3 Token Sales
+
+Token sales occur exclusively via Juicebox contracts; Cobuild does not sell tokens directly. We make no representations that Tokens are securities or investments; users assume all regulatory risks. Cobuild does not solicit investments and users must comply with applicable securities laws. We do not provide investment, financial, or tax advice; all trades are unsolicited and at your risk; Tokens are not securities or derivatives—consult advisors.
+
+### 5.4 On-Chain Accuracy & Rounding
+
+Cobuild disclaims liability for rounding errors, blockchain re-orgs, and mempool front-running. Cobuild does not provide MEV protection; transactions may be reordered by miners or block producers.
+
+### 5.5 Variable Administrative Fee
+
+Cobuild charges variable administrative fees on escrowed grant rounds, disclosed per program, not to exceed 5% of funds processed per grant round unless expressly disclosed on the Interface.
+
+---
+
+## 6. Fees, Refunds & Taxes
+
+### 6.1 Non-Refundable Costs
+
+Gas fees, bonding-curve deposits, application bonds, and network fees are non-refundable, except as required under EU consumer law or card-network rules.
+
+### 6.2 Fee Disclosure & Deduction Method
+
+Fees are transparently disclosed in the UI or contract parameters.
+
+### 6.3 User Tax Obligations
+
+Users are solely responsible for reporting and paying applicable taxes. All fees non-refundable except as required by law. We make no representations on tax implications; report/remit to authorities. Tax consequences (e.g., capital gains) are your sole responsibility—no advice provided.
+
+---
+
+## 7. User Obligations & Prohibited Conduct
+
+### 7.1 General Conduct
+
+Use the platform lawfully and in good faith.
+
+### 7.2 Prohibited Activities
+
+Includes sanctions evasion, Sybil attacks, rug pulls, malware, phishing, IP infringement, exploitation, hate speech, malicious reverse engineering beyond the scope permitted by the GPL license, data scraping, automated harvesting, market manipulation (e.g., wash trading, pumping/dumping), securities or derivatives violations, and sale of stolen/illegal property.
+
+### 7.3 Wallet Security
+
+Users maintain exclusive custody of their wallets. Cobuild is not liable for compromised keys.
+
+---
+
+## 8. Intellectual Property
+
+### 8.1 Software Licence
+
+GPL-3.0 license governs the protocol and front-end.
+
+### 8.2 Trademarks & Branding
+
+All trademarks and branding © 2023-2025 Just Cobuild, Co. ™.
+
+### 8.3 User-Generated Content Licence
+
+Cobuild holds a worldwide, non-exclusive right to display and sublicense to third-party indexers and front-ends publicly available on-chain and Farcaster data.
+
+### 8.4 DMCA & Takedown Procedure
+
+Report infringements via [legal@justco.build](mailto:legal@justco.build) or by mail to DMCA Agent, Just Cobuild Co., 131 Continental Dr Suite 305, Newark DE 19713.
+
+---
+
+## 9. Privacy & Data
+
+### 9.1 Data Collected
+
+Cobuild collects wallet addresses, on-chain activity, and minimal telemetry. We currently do not set tracking cookies or similar technologies. If that changes we will update this Notice before activation.
+
+### 9.2 Use of Data
+
+Collected data is used for analytics, security, and service improvements, based on legitimate interests for usage analytics.
+
+### 9.3 Privacy Notice
+
+See Cobuild’s Privacy Notice for GDPR and CCPA details.
+
+---
+
+## 10. Security & Vulnerability Reporting
+
+### 10.1 Bug-Report Channel
+
+Report bugs at [security@justco.build](mailto:security@justco.build).
+
+### 10.2 No Formal Bounty Programme
+
+Cobuild may offer discretionary rewards for reported vulnerabilities. Cobuild will not pursue legal action for good-faith discovery and 90-day coordinated disclosure of vulnerabilities.
+
+### 10.3 Liability for Exploits
+
+Cobuild is only liable for gross negligence or willful misconduct.
+
+---
+
+## 11. Disclaimers of Warranties
+
+### 11.1 AS-IS / AS-AVAILABLE
+
+All services provided without warranties of any kind, express or implied, including but not limited to warranties of merchantability, fitness for a particular purpose, title, and non-infringement.
+
+### 11.2 Blockchain Risks
+
+You assume all blockchain-related risks including smart-contract bugs and volatility. Cobuild explicitly disclaims responsibility for Layer-2 bridges or wrapped assets.
+
+### 11.3 Third-Party Services
+
+Flows.wtf integrates with third-party services including Juicebox, Farcaster, and various wallet providers. You are responsible for reviewing their respective terms of service and privacy policies. Cobuild disclaims all liability for issues, outages, security breaches, or other problems arising from these third-party services.
+
+### 11.4 Regulatory & Tax Disclaimer
+
+Cobuild does not provide legal, tax, or investment advice.
+
+---
+
+## 12. Limitation of Liability
+
+### 12.1 Total Waiver Limitation
+
+Cobuild disclaims all liability for direct, indirect, incidental, or consequential damages. Nothing in this Section limits liability for fraud, intentional misconduct, or gross negligence where such limitation is unenforceable. Cobuild has no liability for third-party acts.
+
+### 12.2 Statutory Fallback
+
+If unenforceable, maximum aggregate liability per user, aggregate, is the greater of USD 100 or total fees paid by you in the 12 months preceding the claim, except where prohibited by applicable law, such as mandatory consumer rights in the EU.
+
+### 12.3 No Fiduciary Duties
+
+No fiduciary relationship is created between users and Cobuild.
+
+---
+
+## 13. Indemnification
+
+### 13.1 User Duty to Indemnify
+
+You indemnify Cobuild against claims arising from: (a) illegal use of the platform, (b) tax defaults or failures to meet tax obligations, (c) IP infringement including unauthorized use of copyrighted materials or trademarks, and (d) sanctions violations or prohibited transactions. Cobuild will promptly notify you of any claim and may assume exclusive defense.
+
+### 13.2 Procedure
+
+Provide notice, cooperate in defense, and no settlements without consent.
+
+---
+
+## 14. Termination & Suspension
+
+### 14.1 Cobuild Termination Rights
+
+Cobuild may suspend service immediately or after reasonable notice at its discretion for violations or legal obligations.
+
+### 14.2 Effect of Termination
+
+Interface access revoked, but smart contracts remain accessible.
+
+### 14.3 Survival
+
+Sections 8–13, 15-18 (including §16) survive termination.
+
+---
+
+## 15. Governing Law & Dispute Resolution
+
+### 15.1 Governing Law
+
+Delaware law governs.
+
+### 15.2 Venue & Arbitration
+
+Disputes shall be resolved through informal negotiation for 60 days, then by binding arbitration under JAMS Rules. Arbitration shall be confidential. The Federal Arbitration Act governs the interpretation and enforcement of this Section. Arbitration fees are set by the JAMS Consumer Rules; if deemed excessive Cobuild will pay the arbitrator's fees. You may opt out of arbitration by emailing legal@justco.build with subject line "Arbitration Opt-Out" within 30 days of first acceptance. Opt-out notices may also be mailed to: Just Cobuild – Legal, 131 Continental Dr Suite 305, Newark DE 19713, USA. Delaware courts have exclusive jurisdiction for injunctive relief and award enforcement. You retain the right to bring individual small-claims actions. If you are a consumer resident of California, arbitration will be held in California and governed by California law, with the right to small claims option and discovery rights.
+
+### 15.3 Informal Negotiation
+
+Mandatory 60-day negotiation period before arbitration.
+
+### 15.4 Class-Action & Jury-Trial Waiver
+
+Class actions and jury trials explicitly waived.
+
+---
+
+## 16. Changes to Terms & Notice
+
+### 16.1 Versioning
+
+Terms include git commit hash and update date.
+
+### 16.2 Notice Mechanism
+
+Notices via flows.wtf, in-app, email (if you have linked or provided one through the Interface), or RSS 30 days prior to changes.
+
+### 16.3 Continued Use
+
+Continued use constitutes acceptance.
+
+---
+
+## 17. Contact & Registered Agent
+
+Just Cobuild, Co., 131 Continental Dr Suite 305, Newark DE 19713 USA. Email: [legal@justco.build](mailto:legal@justco.build), [security@justco.build](mailto:security@justco.build).
+
+Service of process: Northwest Registered Agent LLC, 8 The Green, Suite B, Dover DE 19901.
+
+---
+
+## 18. Miscellaneous
+
+Nothing in these Terms shall be construed to create a partnership, joint venture, agency, or fiduciary relationship. Includes assignment restrictions, entire agreement, severability, force majeure (including network partition, chain re-org, government regulation, court or DAO-level hard fork, act of God, war, pandemic, public-health emergency, and similar events), and headings convenience. Cobuild may freely assign its rights in connection with merger, acquisition, or asset sale.
+
+Cobuild endeavours to make the Interface reasonably accessible and welcomes feedback at [legal@justco.build](mailto:legal@justco.build).
+
+---
+
+## 19. Plain-Language Summary (Non-Binding)
+
+Self-custody, fees non-refundable, experimental tech, liability limited, Delaware jurisdiction. This summary is provided for convenience and does not override the Terms.
+`

--- a/web/app/legal/terms/terms-content.ts
+++ b/web/app/legal/terms/terms-content.ts
@@ -3,7 +3,7 @@ export const TERMS_CONTENT = `
 
 **Effective Date:** July 11, 2025  
 **Snapshot:** "Continuous funding for grassroots projects via streaming smart-contracts."  
-**Commit Hash:** 0000000000000000000000000000000000000000
+**Commit Hash:** 6a8ca5daa71f96bab4e25897349c44346eaf6270
 
 ### IMPORTANT NOTICE
 

--- a/web/components/global/footer.tsx
+++ b/web/components/global/footer.tsx
@@ -92,17 +92,16 @@ export default async function Footer() {
             <nav className="flex flex-col space-y-2 text-sm text-muted-foreground">
               <Link
                 target="_blank"
-                href="https://www.youtube.com/watch?v=lOzCA7bZG_k"
-                className="hover:underline"
-              >
-                What is Nouns?
-              </Link>
-              <Link
-                target="_blank"
                 href="https://farcaster.xyz/rocketman"
                 className="hover:underline"
               >
                 Contact
+              </Link>
+              <Link target="_blank" href="/legal/terms" className="hover:underline">
+                Terms of Service
+              </Link>
+              <Link target="_blank" href="/legal/privacy" className="hover:underline">
+                Privacy Policy
               </Link>
               <HelpCenterItem user={user} identityToken={identityToken} />
             </nav>

--- a/web/components/global/menu.tsx
+++ b/web/components/global/menu.tsx
@@ -14,7 +14,6 @@ const publicOptions = [
   { name: "Explore", href: "/explore" },
   { name: "Impact", href: "/impact" },
   { name: "Apply", href: "/apply" },
-  { name: "Curate", href: "/curate" },
   {
     name: "Search",
     href: "?search",

--- a/web/lib/onchain-startup/data/interface.ts
+++ b/web/lib/onchain-startup/data/interface.ts
@@ -3,6 +3,7 @@ import { SocialProfileUsernames } from "@/lib/social-metrics/social-profile"
 import { AcceleratorId } from "./accelerators"
 
 export interface StartupData {
+  slug: string
   acceleratorId: AcceleratorId
   title: string
   image: string

--- a/web/lib/onchain-startup/data/straystrong.ts
+++ b/web/lib/onchain-startup/data/straystrong.ts
@@ -1,6 +1,7 @@
 import { StartupData } from "./interface"
 
 export const straystrong = {
+  slug: "straystrong",
   acceleratorId: "vrbs",
   title: "Stray Strong",
   image:

--- a/web/lib/onchain-startup/data/vrbscoffee.ts
+++ b/web/lib/onchain-startup/data/vrbscoffee.ts
@@ -1,6 +1,7 @@
 import { StartupData } from "./interface"
 
 export const vrbscoffee = {
+  slug: "vrbscoffee",
   acceleratorId: "vrbs",
   title: "VRBS Coffee",
   image:

--- a/web/lib/onchain-startup/startup.ts
+++ b/web/lib/onchain-startup/startup.ts
@@ -18,6 +18,10 @@ const startups = {
   },
 } as const
 
+const startupIdBySlug = Object.fromEntries(
+  Object.entries(startups).map(([id, startup]) => [startup.slug, id]),
+) as Record<string, string>
+
 export async function getStartup(id: string) {
   const startup = getStartupData(id)
 
@@ -36,7 +40,14 @@ export async function getStartup(id: string) {
     accelerator,
     allocator,
     id,
+    slug: startup.slug,
   }
+}
+
+export function getStartupIdFromSlug(slug: string) {
+  const id = startupIdBySlug[slug]
+  if (!id) throw new Error("Startup not found")
+  return id
 }
 
 export type Startup = Awaited<ReturnType<typeof getStartup>>

--- a/web/lib/onchain-startup/startup.ts
+++ b/web/lib/onchain-startup/startup.ts
@@ -44,9 +44,10 @@ export async function getStartup(id: string) {
   }
 }
 
-export function getStartupIdFromSlug(slug: string) {
+export function getStartupIdFromSlug(slug: string): string | null {
   const id = startupIdBySlug[slug]
-  if (!id) throw new Error("Startup not found")
+  if (!id) return null
+
   return id
 }
 


### PR DESCRIPTION
## Summary
- allow slug-based startup redirects
- add `slug` field to StartupData
- update VRBS Coffee and Stray Strong data with slugs
- reuse the custom flow dynamic route to handle startup slugs

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build` *(fails: Missing Alchemy env var)*

------
https://chatgpt.com/codex/tasks/task_e_687046c273908327ae50bcd590898916